### PR TITLE
Output improvements on the OSI framework test plugin.

### DIFF
--- a/qemu/panda_plugins/config.panda
+++ b/qemu/panda_plugins/config.panda
@@ -31,6 +31,7 @@ tralign
 printstack
 tainted_branch
 osi
+osi_test
 win7x86intro
 memstrings
 asidstory

--- a/qemu/panda_plugins/osi_test/Makefile
+++ b/qemu/panda_plugins/osi_test/Makefile
@@ -2,7 +2,7 @@
 
 # Set your plugin name here. It does not have to correspond to the name
 # of the directory in which your plugin resides.
-PLUGIN_NAME=testintro
+PLUGIN_NAME=osi_test
 
 # Include the PANDA Makefile rules
 include ../panda.mak

--- a/qemu/panda_plugins/osi_test/README.md
+++ b/qemu/panda_plugins/osi_test/README.md
@@ -10,4 +10,9 @@ By default, the `osi_test` plugin invokes the OSI code every time that the Page 
 
 Invocation frequency can be increased by commenting out the definition of the `INVOKE_FREQ_PGD` macro in the code. Then, OSI code will be invoked before the execution of each basic block. Be warned that this may be too frequent and even small traces will take a long time to be replayed.
 
+## Output normalizer
+Script [osi_test_normalize.py][osi_test_normalize] can be used to make regression testing easier.
+The script will strip out any cruft coming from debug printing and print process and library lists in a normalized format.
+
 [osi]: ../osi
+[osi_test_normalize]: osi_test_normalize.py

--- a/qemu/panda_plugins/osi_test/README.md
+++ b/qemu/panda_plugins/osi_test/README.md
@@ -1,0 +1,13 @@
+# osi_test plugin
+
+This plugin is meant to test the functionality of the [PANDA OS introspection framework][osi]. To run, it requires to first load the `osi` framework plugin and a proper guest-os-specific plugin. e.g.
+
+```
+./i386-softmmu/qemu-system-i386 -vnc :1 -panda 'osi;osi_linux;osi_test' -replay mytrace
+```
+
+By default, the `osi_test` plugin invokes the OSI code every time that the Page Directory register is written to.
+
+Invocation frequency can be increased by commenting out the definition of the `INVOKE_FREQ_PGD` macro in the code. Then, OSI code will be invoked before the execution of each basic block. Be warned that this may be too frequent and even small traces will take a long time to be replayed.
+
+[osi]: ../osi

--- a/qemu/panda_plugins/osi_test/osi_test.c
+++ b/qemu/panda_plugins/osi_test/osi_test.c
@@ -16,8 +16,8 @@ PANDAENDCOMMENT */
 #define __STDC_FORMAT_MACROS
 
 // Choose a granularity for the OSI code to be invoked.
-#define GRANULARITY_PGD
-//#define GRANULARITY_BBL
+#define INVOKE_FREQ_PGD
+//#define INVOKE_FREQ_BBL
 
 #include "config.h"
 #include "qemu-common.h"
@@ -40,7 +40,7 @@ int before_block_exec(CPUState *env, TranslationBlock *tb) {
 
     OsiModules *ms = get_libraries(env, current);
     if (ms == NULL) {
-        printf("No dynamic libraries could mapped.\n");
+        printf("No mapped dynamic libraries.\n");
     }
     else {
         printf("Dynamic libraries list (%d libs):\n", ms->num);
@@ -76,7 +76,7 @@ int vmi_pgd_changed(CPUState *env, target_ulong old_pgd, target_ulong new_pgd) {
 }
 
 bool init_plugin(void *self) {
-#if defined(GRANULARITY_PGD)
+#if defined(INVOKE_FREQ_PGD)
     // relatively short execution
     panda_cb pcb = { .after_PGD_write = vmi_pgd_changed };
     panda_register_callback(self, PANDA_CB_VMI_PGD_CHANGED, pcb);

--- a/qemu/panda_plugins/osi_test/osi_test_normalize.py
+++ b/qemu/panda_plugins/osi_test/osi_test_normalize.py
@@ -1,0 +1,68 @@
+#!/usr/bin/env python
+#
+# Normalizer for osi_test output.
+#
+# Assumption: after the end of a process/lib list, some
+# other line must follow *before* the next heading line.
+
+from __future__ import print_function
+import fileinput
+import re
+
+PROCS_HEAD_RE = r'\(([0-9]+) procs\)'
+PROCS_LIST_RE = r'\s+(\S+)\s+([0-9]+)\s+([0-9]+)'
+LIBS_HEAD_RE = r'\(([0-9]+) libs\)'
+LIBS_LIST_RE = r'\s+(0x[0-9a-f]+)\s+([0-9]+)\s+(\S+)\s+(\S+)'
+
+PROCS_HR = 3*'*' + "%04d" + 33*'*'
+LIBS_HR = 3*'%%' + "%04d" + 33*'%%'
+
+IN_PROCESS_LIST = False
+IN_LIBRARY_LIST = False
+
+nproclist = 0
+nliblist = 0
+
+for line in fileinput.input():
+    if IN_PROCESS_LIST:
+        m = re.match(PROCS_LIST_RE, line)
+        if m:
+            # print a normalized line
+            t = (m.group(1), int(m.group(2)), int(m.group(3)))
+            print(*t)
+            procset.add(t)
+        else:
+            assert (len(procset) == nproc), "Process list length mismatch."
+            IN_PROCESS_LIST = False
+            print(PROCS_HR % (nproclist))
+            nproclist += 1
+    #-------------------------------------------------------
+    elif IN_LIBRARY_LIST:
+        m = re.match(LIBS_LIST_RE, line)
+        if m:
+            # print a normalized line
+            t = (m.group(1), int(m.group(2)), m.group(3), m.group(4))
+            print(*t)
+            libset.add(t)
+        else:
+            assert (len(libset) == nlib), "Library list length mismatch."
+            IN_LIBRARY_LIST = False
+            print(LIBS_HR % (nliblist))
+            nliblist += 1
+    #-------------------------------------------------------
+    else:
+        # check for process list heading
+        m = re.search(PROCS_HEAD_RE, line)
+        if m:
+            IN_PROCESS_LIST = True
+            nproc = int(m.group(1))
+            procset = set()
+            print(PROCS_HR % (nproclist))
+
+        # check for library list heading
+        m = re.search(LIBS_HEAD_RE, line)
+        if m:
+            IN_LIBRARY_LIST = True
+            nlib = int(m.group(1))
+            libset = set()
+            print(LIBS_HR % (nliblist))

--- a/qemu/panda_plugins/testintro/testintro.c
+++ b/qemu/panda_plugins/testintro/testintro.c
@@ -15,6 +15,10 @@ PANDAENDCOMMENT */
 // the PRIx64 macro
 #define __STDC_FORMAT_MACROS
 
+// Choose a granularity for the OSI code to be invoked.
+#define GRANULARITY_PGD
+//#define GRANULARITY_BBL
+
 #include "config.h"
 #include "qemu-common.h"
 
@@ -25,34 +29,39 @@ PANDAENDCOMMENT */
 bool init_plugin(void *);
 void uninit_plugin(void *);
 
+int vmi_pgd_changed(CPUState *env, target_ulong old_pgd, target_ulong new_pgd);
 int before_block_exec(CPUState *env, TranslationBlock *tb);
 
 int before_block_exec(CPUState *env, TranslationBlock *tb) {
     int i;
 
     OsiProc *current = get_current_process(env);
-    printf("Current process: %s, PID %04x PPID %04x\n", current->name, current->pid, current->ppid);
-    OsiProcs *ps;
-    ps = get_processes(env);
+    printf("Current process: %s PID:" TARGET_FMT_ld " PPID:" TARGET_FMT_ld "\n", current->name, current->pid, current->ppid);
+
+    OsiModules *ms = get_libraries(env, current);
+    if (ms == NULL) {
+        printf("No dynamic libraries could mapped.\n");
+    }
+    else {
+        printf("Dynamic libraries list (%d libs):\n", ms->num);
+        for (i = 0; i < ms->num; i++)
+            printf("\t0x" TARGET_FMT_lx "\t" TARGET_FMT_ld "\t%-24s %s\n", ms->module[i].base, ms->module[i].size, ms->module[i].name, ms->module[i].file);
+    }
+
+    printf("\n");
+
+    OsiProcs *ps = get_processes(env);
     if (ps == NULL) {
         printf("Process list not available.\n");
     }
     else {
         printf("Process list (%d procs):\n", ps->num);
         for (i = 0; i < ps->num; i++)
-            printf("  %-16s %04x %04x\n", ps->proc[i].name, ps->proc[i].pid, ps->proc[i].ppid);
+            printf("  %-16s\t" TARGET_FMT_ld "\t" TARGET_FMT_ld "\n", ps->proc[i].name, ps->proc[i].pid, ps->proc[i].ppid);
     }
-    OsiModules *ms;
-    ms = get_libraries(env, current);
-    if (ms == NULL) {
-        printf("DLL list is paged out.\n");
-    }
-    else {
-        printf("DLL list (%d libs):\n", ms->num);
-        for (i = 0; i < ms->num; i++)
-            printf("  %08x %08x %s %s\n", ms->module[i].base, ms->module[i].size, ms->module[i].name, ms->module[i].file);
-    }
-    
+
+    printf("\n-------------------------------------------------\n\n");
+
     // Cleanup
     free_osiproc(current);
     free_osiprocs(ps);
@@ -61,9 +70,21 @@ int before_block_exec(CPUState *env, TranslationBlock *tb) {
     return 0;
 }
 
+int vmi_pgd_changed(CPUState *env, target_ulong old_pgd, target_ulong new_pgd) {
+    // tb argument is not used by before_block_exec()
+    return before_block_exec(env, NULL);
+}
+
 bool init_plugin(void *self) {
+#if defined(GRANULARITY_PGD)
+    // relatively short execution
+    panda_cb pcb = { .after_PGD_write = vmi_pgd_changed };
+    panda_register_callback(self, PANDA_CB_VMI_PGD_CHANGED, pcb);
+#else
+    // expect this to take forever to run
     panda_cb pcb = { .before_block_exec = before_block_exec };
     panda_register_callback(self, PANDA_CB_BEFORE_BLOCK_EXEC, pcb);
+#endif
 
     if(!init_osi_api()) return false;
 


### PR DESCRIPTION
* Improvements in the output format of the OSI framework test plugin.
* Eliminated compile-time warnings. 
* Added some documentation on how to run it.
* Renamed the plugin from `testintro` to `osi_test` so that  it is easier to spot.