### PR TITLE
Fixing typo in panda_install.bash

### DIFF
--- a/panda_install.bash
+++ b/panda_install.bash
@@ -19,7 +19,7 @@ sudo apt-get -y install libtool
 
 # this will install panda in ~/git/panda
 
-mkidr -p ~/git
+mkdir -p ~/git
 
 cd ~/git
 git clone https://github.com/moyix/panda.git


### PR DESCRIPTION
Currently the script is broken if there is no ~/git folder