### PR TITLE
Make the filename of the reduced trace consistent

### DIFF
--- a/docs/UAF.md
+++ b/docs/UAF.md
@@ -103,7 +103,7 @@ reported as the first match for `<html`) and end at `1122107469`, the
 first match for `"has stopped working`.
 
 	panda/qemu/x86_64-softmmu/qemu-system-x86_64 -m 1024 -replay cve-2011-1255-crash \
-        -display none -panda 'scissors:start=398546927,end=1122107469,name=reduced_crash`
+        -display none -panda 'scissors:start=398546927,end=1122107469,name=crash_reduced`
 
 Once this runs, we'll have a replay of around 700 million instructions
 -- about half the size of the original.


### PR DESCRIPTION
The trace is called reduced_crash in the creation command but later in the following commands is referred to as crash_reduced.

I got stuck with cryptic errors like:

    qemu-system-x86_64: Could not open VM state file
    Failed to load snapshot for replay: -22

But the cause was pretty simple :P