### PR TITLE
Patching PANDA to support runtime enable and disable of callbacks.

### DIFF
--- a/docs/PANDA.md
+++ b/docs/PANDA.md
@@ -104,6 +104,10 @@ This can be used to allow one plugin to call functions another, since the handle
 
 Load a PANDA plugin. The `filename` parameter is currently interpreted as a simple filename; no searching is done (this may change in the future). This can be used to allow one plugin to load another.
 
+	void   panda_unload_plugin(void *plugin);
+
+Unload a PANDA plugin. This can be used to allow one plugin to unload another one.
+
 	void   panda_disable_plugin(void *plugin);
 
 Disables callbacks registered by a PANDA plugin. This can be used to allow one plugin to temporarily disable another one.

--- a/docs/PANDA.md
+++ b/docs/PANDA.md
@@ -104,6 +104,15 @@ This can be used to allow one plugin to call functions another, since the handle
 
 Load a PANDA plugin. The `filename` parameter is currently interpreted as a simple filename; no searching is done (this may change in the future). This can be used to allow one plugin to load another.
 
+	void   panda_disable_plugin(void *plugin);
+
+Disables callbacks registered by a PANDA plugin. This can be used to allow one plugin to temporarily disable another one.
+
+	void   panda_enable_plugin(void *plugin);
+
+Enables callbacks registered by a PANDA plugin. This can be used to re-enable callbacks of a plugin that was disabled.
+
+
 ### Argument handling
 
 PANDA allows plugins to receive options on the command line. Each option should look like `-panda-arg <plugin_name>:<key>=<value>`.

--- a/docs/ppp.md
+++ b/docs/ppp.md
@@ -24,8 +24,9 @@ they might permit A to obtain intermediate results from B.  So, the
 idea here is that A wants to control or communicate with B.
 
 Note that Way 1 is already well supported by the functions
-`panda_load_plugin` and `panda_unload_plugin`.  See `panda_plugin.h`
-for more details.
+`panda_load_plugin` / `panda_unload_plugin` and `panda_enable_plugin` / `panda_disable_plugin`
+(the former completely load or unload plugins while the latter allow to temporarily enable or
+disable callbacks registered by a given plugin).  See `panda_plugin.h` for more details.
 
 The interactions described in Ways 2 and 3, however, are tricky
 because panda plugins are dynamically loaded.  Thus, even if Plugin A

--- a/qemu/cpu-exec.c
+++ b/qemu/cpu-exec.c
@@ -177,13 +177,13 @@ static TranslationBlock *tb_find_slow(CPUState *env,
  not_found:
    /* if no translated code available, then translate it now */
 
-    for(plist = panda_cbs[PANDA_CB_BEFORE_BLOCK_TRANSLATE]; plist != NULL; plist = plist->next) {
+    for(plist = panda_cbs[PANDA_CB_BEFORE_BLOCK_TRANSLATE]; plist != NULL; plist = panda_cb_list_next(plist)) {
         plist->entry.before_block_translate(env, pc);
     }
 
     tb = tb_gen_code(env, pc, cs_base, flags, 0);
 
-    for(plist = panda_cbs[PANDA_CB_AFTER_BLOCK_TRANSLATE]; plist != NULL; plist = plist->next) {
+    for(plist = panda_cbs[PANDA_CB_AFTER_BLOCK_TRANSLATE]; plist != NULL; plist = panda_cb_list_next(plist)) {
         plist->entry.after_block_translate(env, tb);
     }
 
@@ -757,7 +757,7 @@ int cpu_exec(CPUState *env)
                 bool panda_invalidate_tb = false;
                 if (unlikely(!bb_invalidate_done)) {
                     for(plist = panda_cbs[PANDA_CB_BEFORE_BLOCK_EXEC_INVALIDATE_OPT];
-                            plist != NULL; plist = plist->next) {
+                            plist != NULL; plist = panda_cb_list_next(plist)) {
                         panda_invalidate_tb |=
                             plist->entry.before_block_exec_invalidate_opt(env, tb);
                     }
@@ -871,7 +871,7 @@ int cpu_exec(CPUState *env)
 
                         // PANDA instrumentation: before basic block exec
                         for(plist = panda_cbs[PANDA_CB_BEFORE_BLOCK_EXEC];
-                                plist != NULL; plist = plist->next) {
+                                plist != NULL; plist = panda_cb_list_next(plist)) {
                             plist->entry.before_block_exec(env, tb);
                         }
 
@@ -887,7 +887,7 @@ int cpu_exec(CPUState *env)
                         next_tb = tcg_qemu_tb_exec(env, tc_ptr);
 #endif
 
-                        for(plist = panda_cbs[PANDA_CB_AFTER_BLOCK_EXEC]; plist != NULL; plist = plist->next) {
+                        for(plist = panda_cbs[PANDA_CB_AFTER_BLOCK_EXEC]; plist != NULL; plist = panda_cb_list_next(plist)) {
                             plist->entry.after_block_exec(env, tb, (TranslationBlock *)(next_tb & ~3));
                         }
 

--- a/qemu/exec.c
+++ b/qemu/exec.c
@@ -4185,7 +4185,7 @@ static int cpu_physical_memory_rw_ex(target_phys_addr_t addr, uint8_t *buf,
                 if (rr_mode == RR_REPLAY) {
                     // run all callbacks registered for cpu_physical_memory_rw ram case
                     panda_cb_list *plist;
-                    for (plist = panda_cbs[PANDA_CB_REPLAY_BEFORE_CPU_PHYSICAL_MEM_RW_RAM]; plist != NULL; plist = plist->next) {
+                    for (plist = panda_cbs[PANDA_CB_REPLAY_BEFORE_CPU_PHYSICAL_MEM_RW_RAM]; plist != NULL; plist = panda_cb_list_next(plist)) {
                         plist->entry.replay_before_cpu_physical_mem_rw_ram(cpu_single_env, is_write, buf, addr1, l);
                     }
                 }
@@ -4254,7 +4254,7 @@ static int cpu_physical_memory_rw_ex(target_phys_addr_t addr, uint8_t *buf,
                 if (rr_mode == RR_REPLAY) {
                     // run all callbacks registered for cpu_physical_memory_rw ram case
                     panda_cb_list *plist;
-                    for (plist = panda_cbs[PANDA_CB_REPLAY_BEFORE_CPU_PHYSICAL_MEM_RW_RAM]; plist != NULL; plist = plist->next) {
+                    for (plist = panda_cbs[PANDA_CB_REPLAY_BEFORE_CPU_PHYSICAL_MEM_RW_RAM]; plist != NULL; plist = panda_cb_list_next(plist)) {
                         plist->entry.replay_before_cpu_physical_mem_rw_ram(cpu_single_env, is_write, buf, addr1, l);
                     }
                 }

--- a/qemu/linux-user/syscall.c
+++ b/qemu/linux-user/syscall.c
@@ -4622,7 +4622,7 @@ abi_long do_syscall(void *cpu_env, int num, abi_long arg1,
 
     panda_cb_list *plist;
     for(plist = panda_cbs[PANDA_CB_USER_BEFORE_SYSCALL]; plist != NULL;
-            plist = plist->next) {
+            plist = panda_cb_list_next(plist)) {
         plist->entry.user_before_syscall(cpu_env, fcntl_flags_tbl,
                                          num, arg1, arg2, arg3, arg4,
                                          arg5, arg6, arg7, arg8);
@@ -8174,7 +8174,7 @@ fail:
         print_syscall_ret(num, ret);
 
     for(plist = panda_cbs[PANDA_CB_USER_AFTER_SYSCALL]; plist != NULL;
-            plist = plist->next) {
+            plist = panda_cb_list_next(plist)) {
         plist->entry.user_after_syscall(cpu_env, fcntl_flags_tbl,num, arg1,
                                         arg2, arg3, arg4, arg5, arg6, arg7,
                                         arg8, p, ret);

--- a/qemu/panda_helper_impl.h
+++ b/qemu/panda_helper_impl.h
@@ -14,7 +14,7 @@ PANDAENDCOMMENT */
 void helper_panda_insn_exec(target_ulong pc) {
     // PANDA instrumentation: before basic block 
     panda_cb_list *plist;
-    for(plist = panda_cbs[PANDA_CB_INSN_EXEC]; plist != NULL; plist = plist->next) {
+    for(plist = panda_cbs[PANDA_CB_INSN_EXEC]; plist != NULL; plist = panda_cb_list_next(plist)) {
         plist->entry.insn_exec(env, pc);
     }
 }

--- a/qemu/panda_plugin.c
+++ b/qemu/panda_plugin.c
@@ -180,6 +180,7 @@ void panda_register_callback(void *plugin, panda_cb_type type, panda_cb cb) {
     new_list->owner = plugin;
     new_list->prev = NULL;
     new_list->next = NULL;
+    new_list->enabled = true;
     if(panda_cbs[type] != NULL) {
         new_list->next = panda_cbs[type];
         panda_cbs[type]->prev = new_list;
@@ -214,6 +215,48 @@ void panda_unregister_callbacks(void *plugin) {
                 plist = plist->next;
             }
         }
+    }
+}
+
+void panda_enable_plugin(void *plugin) {
+    int i;
+    for (i = 0; i < PANDA_CB_LAST; i++) {
+        panda_cb_list *plist;
+        plist = panda_cbs[i];
+        while(plist != NULL) {
+            if (plist->owner == plugin) {
+                plist->enabled = true;
+            }
+            plist = plist->next;
+        }
+    }
+}
+
+void panda_disable_plugin(void *plugin) {
+    int i;
+    for (i = 0; i < PANDA_CB_LAST; i++) {
+        panda_cb_list *plist;
+        plist = panda_cbs[i];
+        while(plist != NULL) {
+            if (plist->owner == plugin) {
+                plist->enabled = false;
+            }
+            plist = plist->next;
+        }
+    }
+}
+
+panda_cb_list* panda_cb_list_next(panda_cb_list* plist) {
+    // Allows to navigate the callback linked list skipping disabled callbacks
+    panda_cb_list* node = plist->next;
+    if (node == NULL) {
+        return node;
+    }
+
+    if (node->enabled) {
+        return node;
+    } else {
+        return panda_cb_list_next(node);
     }
 }
 
@@ -529,7 +572,7 @@ void hmp_panda_list_plugins(Monitor *mon, const QDict *qdict) {
 void hmp_panda_plugin_cmd(Monitor *mon, const QDict *qdict) {
     panda_cb_list *plist;
     const char *cmd = qdict_get_try_str(qdict, "cmd");
-    for(plist = panda_cbs[PANDA_CB_MONITOR]; plist != NULL; plist = plist->next) {
+    for(plist = panda_cbs[PANDA_CB_MONITOR]; plist != NULL; plist = panda_cb_list_next(plist)) {
         plist->entry.monitor(mon, cmd);
     }
 }

--- a/qemu/panda_plugin.h
+++ b/qemu/panda_plugin.h
@@ -513,7 +513,11 @@ struct _panda_cb_list {
     void *owner;
     panda_cb_list *next;
     panda_cb_list *prev;
+    bool enabled;
 };
+panda_cb_list* panda_cb_list_next(panda_cb_list* plist);
+void panda_enable_plugin(void *plugin);
+void panda_disable_plugin(void *plugin);
 
 // Structure to store metadata about a plugin
 typedef struct panda_plugin {

--- a/qemu/panda_plugins/syscalls/syscalls.cpp
+++ b/qemu/panda_plugins/syscalls/syscalls.cpp
@@ -219,7 +219,7 @@ static bool returned_check_callback(CPUState *env, TranslationBlock* tb){
     for(auto& retVal :fork_returns){
         if (retVal.retaddr == tb->pc && retVal.process_id == get_asid(env, tb->pc)){
            // we returned from fork
-           for(plist = panda_cbs[PANDA_CB_VMI_AFTER_FORK]; plist != NULL; plist = plist->next) {
+           for(plist = panda_cbs[PANDA_CB_VMI_AFTER_FORK]; plist != NULL; plist = panda_cb_list_next(plist)) {
                 plist->entry.return_from_fork(env);
             }
            // set to 0,0 so we can remove after we finish iterating
@@ -231,7 +231,7 @@ static bool returned_check_callback(CPUState *env, TranslationBlock* tb){
         if(retVal.process_id == get_asid(env, tb->pc) && !in_kernelspace(env)){
         //if (retVal.retaddr == tb->pc /*&& retVal.process_id == get_asid(env, tb->pc)*/){
            // we returned from fork
-           for(plist = panda_cbs[PANDA_CB_VMI_AFTER_EXEC]; plist != NULL; plist = plist->next) {
+           for(plist = panda_cbs[PANDA_CB_VMI_AFTER_EXEC]; plist != NULL; plist = panda_cb_list_next(plist)) {
                 plist->entry.return_from_exec(env);
             }
            // set to 0,0 so we can remove after we finish iterating
@@ -242,7 +242,7 @@ static bool returned_check_callback(CPUState *env, TranslationBlock* tb){
     for(auto& retVal :clone_returns){
         if (retVal.retaddr == tb->pc && retVal.process_id == get_asid(env, tb->pc)){
            // we returned from fork
-           for(plist = panda_cbs[PANDA_CB_VMI_AFTER_CLONE]; plist != NULL; plist = plist->next) {
+           for(plist = panda_cbs[PANDA_CB_VMI_AFTER_CLONE]; plist != NULL; plist = panda_cb_list_next(plist)) {
                 plist->entry.return_from_clone(env);
             }
            // set to 0,0 so we can remove after we finish iterating

--- a/qemu/rr_log.c
+++ b/qemu/rr_log.c
@@ -1160,7 +1160,7 @@ void rr_replay_skipped_calls_internal(RR_callsite_id call_site) {
 		    // run all callbacks registered for hd transfer
 		    RR_hd_transfer_args *hdt = &(args->variant.hd_transfer_args);
 		    panda_cb_list *plist;
-		    for (plist = panda_cbs[PANDA_CB_REPLAY_HD_TRANSFER]; plist != NULL; plist = plist->next) {
+		    for (plist = panda_cbs[PANDA_CB_REPLAY_HD_TRANSFER]; plist != NULL; plist = panda_cb_list_next(plist)) {
 		      plist->entry.replay_hd_transfer
 			(cpu_single_env, 
 			 hdt->type,
@@ -1176,7 +1176,7 @@ void rr_replay_skipped_calls_internal(RR_callsite_id call_site) {
 		    // run all callbacks registered for packet handling
 		    RR_handle_packet_args *hp = &(args->variant.handle_packet_args);
 		    panda_cb_list *plist;
-		    for (plist = panda_cbs[PANDA_CB_REPLAY_HANDLE_PACKET]; plist != NULL; plist = plist->next) {
+		    for (plist = panda_cbs[PANDA_CB_REPLAY_HANDLE_PACKET]; plist != NULL; plist = panda_cb_list_next(plist)) {
 		      plist->entry.replay_handle_packet
 			(cpu_single_env, 
 			 hp->buf,
@@ -1196,7 +1196,7 @@ void rr_replay_skipped_calls_internal(RR_callsite_id call_site) {
                         &(args->variant.net_transfer_args);
                     panda_cb_list *plist;
                     for (plist = panda_cbs[PANDA_CB_REPLAY_NET_TRANSFER];
-                            plist != NULL; plist = plist->next) {
+                            plist != NULL; plist = panda_cb_list_next(plist)) {
                       plist->entry.replay_net_transfer
                         (cpu_single_env, 
                          nta->type,
@@ -1542,7 +1542,7 @@ int rr_do_begin_replay(const char *file_name_full, void *cpu_state) {
   //  vm_stop(0) RUN_STATE_RESTORE_VM);
     panda_cb_list *plist;
     for(plist = panda_cbs[PANDA_CB_BEFORE_REPLAY_LOADVM]; plist != NULL;
-            plist = plist->next) {
+            plist = panda_cb_list_next(plist)) {
         plist->entry.before_loadvm();
     }
   snapshot_ret = load_vmstate_rr(name_buf);

--- a/qemu/softmmu_template.h
+++ b/qemu/softmmu_template.h
@@ -180,12 +180,12 @@ DATA_TYPE REGPARM glue(glue(__ld, SUFFIX), MMUSUFFIX)(target_ulong addr,
     // PANDA instrumentation: memory read
     panda_cb_list *plist;
     for(plist = panda_cbs[PANDA_CB_VIRT_MEM_READ]; plist != NULL;
-            plist = plist->next) {
+            plist = panda_cb_list_next(plist)) {
         plist->entry.virt_mem_read(env, env->panda_guest_pc, addr,
             DATA_SIZE, &res);
     }
     for(plist = panda_cbs[PANDA_CB_PHYS_MEM_READ]; plist != NULL;
-            plist = plist->next) {
+            plist = panda_cb_list_next(plist)) {
         plist->entry.phys_mem_read(env, env->panda_guest_pc,
             cpu_get_phys_addr(env, addr), DATA_SIZE, &res);
     }
@@ -247,7 +247,7 @@ static DATA_TYPE glue(glue(slow_ld, SUFFIX), MMUSUFFIX)(target_ulong addr,
     // rwhelan: redundant?
     /*panda_cb_list *plist;
     for(plist = panda_cbs[PANDA_CB_VIRT_MEM_READ]; plist != NULL;
-            plist = plist->next) {
+            plist = panda_cb_list_next(plist)) {
         plist->entry.virt_mem_read(env, env->panda_guest_pc, addr,
             DATA_SIZE, &res);
     }*/
@@ -332,12 +332,12 @@ void REGPARM glue(glue(__st, SUFFIX), MMUSUFFIX)(target_ulong addr,
     // PANDA instrumentation: memory write
     panda_cb_list *plist;
     for(plist = panda_cbs[PANDA_CB_VIRT_MEM_WRITE]; plist != NULL;
-            plist = plist->next) {
+            plist = panda_cb_list_next(plist)) {
         plist->entry.virt_mem_write(env, env->panda_guest_pc, addr,
             DATA_SIZE, &val);
     }
     for(plist = panda_cbs[PANDA_CB_PHYS_MEM_WRITE]; plist != NULL;
-            plist = plist->next) {
+            plist = panda_cb_list_next(plist)) {
         plist->entry.phys_mem_write(env, env->panda_guest_pc,
             cpu_get_phys_addr(env, addr), DATA_SIZE, &val);
     }
@@ -403,7 +403,7 @@ static void glue(glue(slow_st, SUFFIX), MMUSUFFIX)(target_ulong addr,
     // PANDA instrumentation: memory write
     // rwhelan: redundant?
     /*panda_cb_list *plist;
-    for(plist = panda_cbs[PANDA_CB_VIRT_MEM_WRITE]; plist != NULL; plist = plist->next) {
+    for(plist = panda_cbs[PANDA_CB_VIRT_MEM_WRITE]; plist != NULL; plist = panda_cb_list_next(plist)) {
         plist->entry.virt_mem_write(env, env->panda_guest_pc, addr, DATA_SIZE, &val);
     }*/
 #endif

--- a/qemu/target-arm/helper.c
+++ b/qemu/target-arm/helper.c
@@ -615,7 +615,7 @@ void HELPER(set_cp)(CPUState *env, uint32_t insn, uint32_t val)
         // PANDA instrumentation: guest hypercall
         panda_cb_list *plist;
         for (plist = panda_cbs[PANDA_CB_GUEST_HYPERCALL]; plist != NULL;
-                plist = plist->next){
+                plist = panda_cb_list_next(plist)){
             plist->entry.guest_hypercall(env);
         }
     }
@@ -1375,16 +1375,16 @@ void HELPER(set_cp)(CPUState *env, uint32_t insn, uint32_t val)
     int cp_info = (insn >> 5) & 7;
     int src = (insn >> 16) & 0xf;
     int operand = insn & 0xf;
-    
+
     if (env->cp[cp_num].cp_write)
         env->cp[cp_num].cp_write(env->cp[cp_num].opaque,
                                  cp_info, src, operand, val);
-    
+
     if (cp_num == 7){
         // PANDA instrumentation: guest hypercall
         panda_cb_list *plist;
         for (plist = panda_cbs[PANDA_CB_GUEST_HYPERCALL]; plist != NULL;
-                plist = plist->next){
+                plist = panda_cb_list_next(plist)) {
             plist->entry.guest_hypercall(env);
         }
     }
@@ -1506,14 +1506,14 @@ void HELPER(set_cp15)(CPUState *env, uint32_t insn, uint32_t val)
 	    switch (op2) {
 	    case 0:
                 oldval = env->cp15.c2_base0;
-		for(plist = panda_cbs[PANDA_CB_VMI_PGD_CHANGED]; plist != NULL; plist = plist->next) {
+		for(plist = panda_cbs[PANDA_CB_VMI_PGD_CHANGED]; plist != NULL; plist = panda_cb_list_next(plist)) {
                     plist->entry.after_PGD_write(env, oldval, val);
 		}
 		env->cp15.c2_base0 = val;
 		break;
 	    case 1:
                 oldval = env->cp15.c2_base1;
-		for(plist = panda_cbs[PANDA_CB_VMI_PGD_CHANGED]; plist != NULL; plist = plist->next) {
+		for(plist = panda_cbs[PANDA_CB_VMI_PGD_CHANGED]; plist != NULL; plist = panda_cb_list_next(plist)) {
                     plist->entry.after_PGD_write(env, oldval, val);
 		}
 		env->cp15.c2_base1 = val;

--- a/qemu/target-arm/translate.c
+++ b/qemu/target-arm/translate.c
@@ -10055,7 +10055,7 @@ static inline void gen_intermediate_code_internal(CPUState *env,
         // PANDA: ask if anyone wants execution notification
         bool panda_exec_cb = false;
         panda_cb_list *plist;
-        for(plist = panda_cbs[PANDA_CB_INSN_TRANSLATE]; plist != NULL; plist = plist->next) {
+        for(plist = panda_cbs[PANDA_CB_INSN_TRANSLATE]; plist != NULL; plist = panda_cb_list_next(plist)) {
             panda_exec_cb |= plist->entry.insn_translate(env, dc->pc);
         }
 

--- a/qemu/target-i386/helper.c
+++ b/qemu/target-i386/helper.c
@@ -522,7 +522,7 @@ void cpu_x86_update_cr3(CPUX86State *env, target_ulong new_cr3)
     /* Do we want to exclude changes when paging is disabled?
     target_ulong oldval;
     oldval = env->cr[3]; */
-    for(plist = panda_cbs[PANDA_CB_VMI_PGD_CHANGED]; plist != NULL; plist = plist->next) {
+    for(plist = panda_cbs[PANDA_CB_VMI_PGD_CHANGED]; plist != NULL; plist = panda_cb_list_next(plist)) {
         plist->entry.after_PGD_write(env, env->cr[3], new_cr3);
     }
     

--- a/qemu/target-i386/op_helper.c
+++ b/qemu/target-i386/op_helper.c
@@ -2124,7 +2124,7 @@ void helper_cpuid(void)
 
     // PANDA instrumentation: guest hypercall
     panda_cb_list *plist;
-    for(plist = panda_cbs[PANDA_CB_GUEST_HYPERCALL]; plist != NULL; plist = plist->next) {
+    for(plist = panda_cbs[PANDA_CB_GUEST_HYPERCALL]; plist != NULL; plist = panda_cb_list_next(plist)) {
         plist->entry.guest_hypercall(env);
     }
 

--- a/qemu/target-i386/translate.c
+++ b/qemu/target-i386/translate.c
@@ -7989,7 +7989,7 @@ static void gen_intermediate_code_internal(CPUState *env,
             // PANDA: ask if anyone wants execution notification
             bool panda_exec_cb = false;
             panda_cb_list *plist;
-            for(plist = panda_cbs[PANDA_CB_INSN_TRANSLATE]; plist != NULL; plist = plist->next) {
+            for(plist = panda_cbs[PANDA_CB_INSN_TRANSLATE]; plist != NULL; plist = panda_cb_list_next(plist)) {
                 panda_exec_cb |= plist->entry.insn_translate(env, pc_ptr);
             }
 

--- a/qemu/translate-all.c
+++ b/qemu/translate-all.c
@@ -153,7 +153,7 @@ int cpu_restore_state(TranslationBlock *tb,
     // PANDA instrumentation: CPU restore state
     panda_cb_list *plist;
     for(plist = panda_cbs[PANDA_CB_CPU_RESTORE_STATE]; plist != NULL;
-            plist = plist->next) {
+            plist = panda_cb_list_next(plist)) {
         plist->entry.cb_cpu_restore_state(env, tb);
     }
  


### PR DESCRIPTION
At the moment is possible to dynamically load or unload plugins. The problem is that it's possible only to completely load/unload plugins and not to switching them off temporarily. This pull request addresses this issue.

To start getting familiar with the PANDA codebase I wanted to develop a plugin that acts as a filter for other plugins.
Example: Plugin A is the filter while Plugin B logs the CPU state. I want to dump the CPU state only when some conditions are satisfied (e.g.: PC=something or ESP=something). So Plugin B just dumps the state for every instruction but Plugin A switches it on and off based on some conditions.

To do so I patched the callback list structure to add a boolean flag `enabled`. Then when navigating the callbacks linked list the function `panda_cb_list_next` returns a pointer to the next enabled callback (skipping the disabled ones).

It is thus possible to use `panda_enable_plugin(void* plugin)` or `panda_disable_plugin(void* plugin)` to temporarily enable or disable a plugin at runtime.

As I started looking into PANDA a few days ago maybe there is a better way to achieve my goal, so feel free to comment or give me any kind of feedback.