### PR TITLE
Changing panda_unload_plugin to receive a plugin as argument

### DIFF
--- a/qemu/panda_plugin.c
+++ b/qemu/panda_plugin.c
@@ -163,6 +163,9 @@ void panda_unload_plugin(void* plugin) {
 }
 
 void panda_unload_plugin_idx(int plugin_idx) {
+    if (plugin_idx >= nb_panda_plugins || plugin_idx < 0) {
+        return;
+    }
     panda_plugin_to_unload = true;
     panda_plugins_to_unload[plugin_idx] = true;
 }
@@ -501,8 +504,9 @@ void qmp_load_plugin(const char *filename, Error **errp) {
 void qmp_unload_plugin(int64_t index, Error **errp) {
     if (index >= nb_panda_plugins || index < 0) {
         // TODO: errp
+    } else {
+        panda_unload_plugin_idx(index);
     }
-    panda_unload_plugin_idx(index);
 }
 
 void qmp_list_plugins(Error **errp) {

--- a/qemu/panda_plugin.c
+++ b/qemu/panda_plugin.c
@@ -152,7 +152,17 @@ void panda_do_unload_plugin(int plugin_idx){
     dlclose(plugin);
 }
 
-void panda_unload_plugin(int plugin_idx) {
+void panda_unload_plugin(void* plugin) {
+    int i;
+    for (i = 0; i < nb_panda_plugins; i++) {
+        if (panda_plugins[i].plugin == plugin) {
+            panda_unload_plugin_idx(i);
+            break;
+        }
+    }
+}
+
+void panda_unload_plugin_idx(int plugin_idx) {
     panda_plugin_to_unload = true;
     panda_plugins_to_unload[plugin_idx] = true;
 }
@@ -492,7 +502,7 @@ void qmp_unload_plugin(int64_t index, Error **errp) {
     if (index >= nb_panda_plugins || index < 0) {
         // TODO: errp
     }
-    panda_unload_plugin(index);
+    panda_unload_plugin_idx(index);
 }
 
 void qmp_list_plugins(Error **errp) {

--- a/qemu/panda_plugin.h
+++ b/qemu/panda_plugin.h
@@ -527,7 +527,8 @@ bool   panda_load_plugin(const char *filename);
 bool   panda_add_arg(const char *arg, int arglen);
 void * panda_get_plugin_by_name(const char *name);
 void   panda_do_unload_plugin(int index);
-void   panda_unload_plugin(int index);
+void   panda_unload_plugin(void* plugin);
+void   panda_unload_plugin_idx(int idx);
 void   panda_unload_plugins(void);
 
 // Doesn't exist in user mode


### PR DESCRIPTION
I find not really convenient the fact of having the function `panda_unload_plugin` to get an index as a parameter. It would be nicer to just get a pointer to a plugin, so we can use `panda_get_plugin_by_name` in combination with it and have a more consistent API. What do you think?

If you agree I can add documentation as well.