### PR TITLE
Compile and cleanup rules for per-plugin object directories.

### DIFF
--- a/qemu/Makefile.target
+++ b/qemu/Makefile.target
@@ -566,11 +566,7 @@ clean:
 	rm -f *.o *.a *~ $(PROGS) nwfpe/*.o fpu/*.o
 	rm -f *.d */*.d tcg/*.o ide/*.o 9pfs/*.o panda/*.o *.bc *.bc1 *.bc2
 	rm -f hmp-commands.h qmp-commands-old.h gdbstub-xml.c
-	rm -f panda_plugins/DroidScope/DS_utils/*.*
-	rm -f panda_plugins/DroidScope/linuxAPI/*.*
-	rm -f panda_plugins/DroidScope/*.*
-	rm -f panda_plugins/utils/*.*
-	rm -f panda_plugins/*.* panda_tools/*
+	find panda_plugins -depth -mindepth 1 -delete
 
 ifdef CONFIG_TRACE_SYSTEMTAP
 	rm -f *.stp

--- a/qemu/panda_plugins/Makefile.example
+++ b/qemu/panda_plugins/Makefile.example
@@ -11,11 +11,15 @@ include ../panda.mak
 # CFLAGS+=
 # LIBS+=
 
-# The main rule for your plugin. Please stick with the panda_ naming
-# convention.
-$(PLUGIN_TARGET_DIR)/$(PLUGIN_NAME).o: $(PLUGIN_SRC_ROOT)/$(PLUGIN_NAME)/$(PLUGIN_NAME).c
+# Object files comprising the plugin.
+PLUGIN_OBJFILES=$(PLUGIN_OBJ_DIR)/$(PLUGIN_NAME).o\
+				$(PLUGIN_OBJ_DIR)/module1.o\
+				$(PLUGIN_OBJ_DIR)/module2.o
 
-$(PLUGIN_TARGET_DIR)/panda_$(PLUGIN_NAME).so: $(PLUGIN_TARGET_DIR)/$(PLUGIN_NAME).o
+.PHONY: all
+
+# Plugin dynamic library. Please stick with the panda_ naming convention.
+$(PLUGIN_TARGET_DIR)/panda_$(PLUGIN_NAME).so: $(PLUGIN_OBJFILES)
 	$(call quiet-command,$(CC) $(QEMU_CFLAGS) -shared -o $@ $^ $(LIBS),"  PLUGIN  $@")
 
-all: $(PLUGIN_TARGET_DIR)/panda_$(PLUGIN_NAME).so
+all: $(PLUGIN_OBJ_DIR) $(PLUGIN_TARGET_DIR)/panda_$(PLUGIN_NAME).so

--- a/qemu/panda_plugins/panda.mak
+++ b/qemu/panda_plugins/panda.mak
@@ -21,6 +21,17 @@ TARGET_PATH=$(SRC_PATH)/target-$(TARGET_BASE_ARCH)
 QEMU_CFLAGS+=-I$(SRC_PATH)/$(TARGET_DIR) -I$(TARGET_PATH) -DNEED_CPU_H -fPIC
 QEMU_CFLAGS+=$(GLIB_CFLAGS)
 
+PLUGIN_OBJ_DIR=$(PLUGIN_TARGET_DIR)/panda_$(PLUGIN_NAME)
+
+$(PLUGIN_OBJ_DIR):
+	@[ -d  $@ ] || mkdir -p $@
+
+$(PLUGIN_OBJ_DIR)/%.o: %.c
+	$(call quiet-command,$(CC) $(QEMU_INCLUDES) $(QEMU_CFLAGS) $(QEMU_DGFLAGS) $(CFLAGS) -c -o $@ $<,"  CC    $@")
+
+$(PLUGIN_OBJ_DIR)/%.o: %.cpp $(GENERATED_HEADERS)
+	$(call quiet-command,$(CXX) $(filter-out -Wnested-externs -Wmissing-prototypes -Wstrict-prototypes -Wold-style-declaration -Wold-style-definition, $(QEMU_INCLUDES) $(QEMU_CFLAGS) $(QEMU_CXXFLAGS) $(QEMU_DGFLAGS) $(CXXFLAGS)) -c -o $@ $<,"  CXX   $@")
+
 $(PLUGIN_TARGET_DIR)/%.o: %.c
 	$(call quiet-command,$(CC) $(QEMU_INCLUDES) $(QEMU_CFLAGS) $(QEMU_DGFLAGS) $(CFLAGS) -c -o $@ $<,"  CC    $@")
 


### PR DESCRIPTION
Currently both `.o` and `.so` files for plugins are dumped in the `panda_plugins` directory. This creates the potential for filename conflicts. E.g. if two different plugins use an `utils.o` object file, they will interfere with each other.
This patch adds rules for having per-plugin directories under `panda_plugins` for holding the intermediate `.o` files. Old rules haven't been touched, so the makefiles of existing plugins will continue to work until they are updated.