### PR TITLE
Process events support for OSI

### DIFF
--- a/qemu/panda_plugins/osi/Makefile
+++ b/qemu/panda_plugins/osi/Makefile
@@ -8,12 +8,20 @@ PLUGIN_NAME=osi
 include ../panda.mak
 
 # If you need custom CFLAGS or LIBS, set them up here
-# CFLAGS+=
 # LIBS+=
+# CFLAGS+=-save-temps
+CXXFLAGS+=-std=c++11
 
-# The main rule for your plugin. Please stick with the panda_ naming
-# convention.
-$(PLUGIN_TARGET_DIR)/panda_$(PLUGIN_NAME).so: $(PLUGIN_TARGET_DIR)/os_intro.o
+PLUGIN_OBJFILES=$(PLUGIN_OBJ_DIR)/os_intro.o
+ifneq (,$(findstring -DOSI_PROC_EVENTS,$(QEMU_CFLAGS)))
+PLUGIN_OBJFILES+=$(PLUGIN_OBJ_DIR)/osi_proc_events.o
+endif
+
+.PHONY: all
+
+# Plugin dynamic library. Please stick with the panda_ naming convention.
+$(PLUGIN_TARGET_DIR)/panda_$(PLUGIN_NAME).so: $(PLUGIN_OBJFILES)
 	$(call quiet-command,$(CC) $(QEMU_CFLAGS) -shared -o $@ $^ $(LIBS),"  PLUGIN  $@")
 
-all: $(PLUGIN_TARGET_DIR)/panda_$(PLUGIN_NAME).so
+all: $(PLUGIN_OBJ_DIR) $(PLUGIN_TARGET_DIR)/panda_$(PLUGIN_NAME).so
+	echo $(PLUGIN_OBJFILES)

--- a/qemu/panda_plugins/osi/os_intro.h
+++ b/qemu/panda_plugins/osi/os_intro.h
@@ -8,5 +8,9 @@ typedef void (*on_get_libraries_t)(CPUState *, OsiProc *, OsiModules**);
 typedef void (*on_free_osiproc_t)(OsiProc *p);
 typedef void (*on_free_osiprocs_t)(OsiProcs *ps);
 typedef void (*on_free_osimodules_t)(OsiModules *ms);
+#ifdef OSI_PROC_EVENTS
+typedef void (*on_new_process_t)(CPUState *, OsiProc *);
+typedef void (*on_finished_process_t)(CPUState *, OsiProc *);
+#endif
 
 #endif 

--- a/qemu/panda_plugins/osi/osi_proc_events.cpp
+++ b/qemu/panda_plugins/osi/osi_proc_events.cpp
@@ -1,0 +1,143 @@
+#include "osi_proc_events.h"
+
+extern "C" {
+#include <osi_int_fns.h>
+}
+
+#include <glib.h>
+#include <string.h>
+#include <algorithm>
+#include <iterator>
+#include <set>
+#include <map>
+
+/*! @brief The global process state. */
+ProcState pstate;
+
+/*! @brief Constructor. */
+ProcState::ProcState(void) {
+	this->pid_set = new PidSet();
+	this->proc_map = new ProcMap();
+	return;
+}
+
+/*! @brief Destructor. */
+ProcState::~ProcState(void) {
+	if (this->pid_set != NULL) delete this->pid_set;
+	if (this->proc_map != NULL) delete this->proc_map;
+
+	// This destructor is called at the end of the replay.
+	// Calling free_osiprocs() may cause a segfault at that point.
+	// Use the generic inline.
+	free_osiprocs_g(this->ps);
+}
+
+/*! @brief Gets a subset of the processes in `ProcMap`. */
+OsiProcs *ProcState::OsiProcsSubset(ProcMap *m, PidSet *s) {
+	int notfound = 0;
+	OsiProcs *ps = (OsiProcs *)g_malloc0(sizeof(OsiProcs));
+
+	ps->proc = g_new0(OsiProc, s->size());
+	for (auto it=s->begin(); it!=s->end(); ++it) {
+		auto p_it = m->find(*it);
+		if (unlikely(p_it == m->end())) {
+			notfound++;
+			continue;
+		}
+		copy_osiproc_g(p_it->second, &ps->proc[ps->num]);
+		ps->num++;
+	}
+
+	if (unlikely(notfound > 0)) LOG_WARN("PEVT: Process mapt didn't include %d processes of the requested subset.", notfound);
+
+	if (ps->num == 0) goto error;
+
+	return ps;
+
+error:
+	free_osiprocs(ps);
+	return NULL;
+}
+
+/*! @brief Updates the ProcState with the new process set.
+ * If `in` and `out` are not NULL, the new and finished processes
+ * will be returned through them.
+ *
+ * @note For efficiency (i.e. to avoid an additional copy),
+ * the passed `ps` becomes part of the ProcState.
+ * Therefore, it must not be freed by the caller.
+ */
+void ProcState::update(OsiProcs *ps, OsiProcs **in, OsiProcs **out){
+	PidSet *pid_set_new = new PidSet();
+	ProcMap *proc_map_new = new ProcMap();
+
+	// copy data to c++ containers
+#ifdef PROC_EVENTS_DBG
+	printf("*+**********\n");
+#endif
+	for (unsigned int i=0; i<ps->num; i++) {
+		OsiProc *p = &ps->proc[i];
+		target_ulong asid = p->asid;
+
+		// Address Space identifier for all kernel tasks is 0.
+		// This is because they have no mm struct associated with them.
+		// Skip them.
+		if (asid == 0) continue;
+
+#ifdef PROC_EVENTS_DBG
+		printf("*\t%-10s\t" TARGET_FMT_lu "\t" TARGET_FMT_lu "\t" TARGET_FMT_lx "\n", p->name, p->pid, p->ppid, p->asid);
+#endif
+
+		pid_set_new->insert(asid);
+		auto ret = proc_map_new->insert(std::make_pair(asid, p));
+
+		// ret type is pair<iterator, bool>
+		if (!ret.second && (asid != 0)) {
+			LOG_INFO("DUP " TARGET_FMT_lu " %s/%s", asid, ((*(ret.first)).second->name), p->name);
+		}
+	}
+#ifdef PROC_EVENTS_DBG
+	printf("*+**********\n");
+#endif
+
+	// extract OsiProcs
+	if (likely(in != NULL && out != NULL)) {
+		// free old data
+		if (*in != NULL) free_osiprocs(*in);
+		if (*out != NULL) free_osiprocs(*out);
+
+		// find the pids of incoming/outgoing process
+		PidSet pid_in, pid_out;
+		std::set_difference(
+			pid_set_new->begin(), pid_set_new->end(),
+			this->pid_set->begin(), this->pid_set->end(),
+			std::inserter(pid_in, pid_in.begin())
+		);
+		std::set_difference(
+			this->pid_set->begin(), this->pid_set->end(),
+			pid_set_new->begin(), pid_set_new->end(),
+			std::inserter(pid_out, pid_out.begin())
+		);
+
+		*in = ProcState::OsiProcsSubset(proc_map_new, &pid_in);
+		*out = ProcState::OsiProcsSubset(this->proc_map, &pid_out);
+	}
+
+	// update ProcState
+	delete this->pid_set;
+	delete this->proc_map;
+	free_osiprocs(this->ps);
+	this->pid_set = pid_set_new;
+	this->proc_map = proc_map_new;
+	this->ps = ps;
+
+	return;
+}
+
+/*!
+ * @brief C wrapper for updating the global process state.
+ */
+void procstate_update(OsiProcs *ps, OsiProcs **in, OsiProcs **out) {
+	pstate.update(ps, in, out);
+}
+

--- a/qemu/panda_plugins/osi/osi_proc_events.h
+++ b/qemu/panda_plugins/osi/osi_proc_events.h
@@ -1,0 +1,81 @@
+#ifndef OSI_PROC_EVENTS_H
+#define OSI_PROC_EVENTS_H
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+#include "config.h"
+#include "qemu-common.h"
+#include "osi_types.h"
+
+#ifdef __cplusplus
+}
+#endif
+
+/*!
+ * @brief Branch prediction hint macros.
+ */
+#define likely(x)       __builtin_expect(!!(x), 1)
+#define unlikely(x)     __builtin_expect(!!(x), 0)
+
+/*!
+ * @brief Debug macros.
+ */
+#define LOG_ERROR(fmt, args...) fprintf(stderr, "ERROR(%s:%s): " fmt "\n", __FILE__, __func__, ## args)
+#define LOG_WARN(fmt, args...) fprintf(stderr, "WARN(%s:%s): " fmt "\n", __FILE__, __func__, ## args)
+#define LOG_INFO(fmt, args...) fprintf(stderr, "INFO(%s:%s): " fmt "\n", __FILE__, __func__, ## args)
+#define PRINT_CONTAINER(c, fmt, args...) do{\
+	int _l = 0;\
+	LOG_INFO("------- " #c " start -------");\
+	for (auto it=(c)->begin(); it!=(c)->end(); ++it){\
+		char _d = _l ? ' ' : '\t';\
+		fprintf(stderr, "%c" fmt, _d, ## args);\
+		_l = (_l + 1) % 10;\
+		if (!_l) fprintf(stderr, "\n");\
+	}\
+	if (_l) fprintf(stderr, "\n");\
+	LOG_INFO("-------- " #c " end --------\n");\
+} while(0)
+
+#ifdef __cplusplus
+#include <set>
+#include <unordered_map>
+typedef std::set<target_ulong> PidSet;
+typedef std::unordered_map<target_ulong, OsiProc *> ProcMap;
+
+class ProcState {
+	public:
+		ProcState();
+		~ProcState();
+		void update(OsiProcs *ps, OsiProcs **in, OsiProcs **out);
+
+	private:
+		PidSet *pid_set = NULL;		/**< pids from previous run */
+		ProcMap *proc_map = NULL;	/**< pid to OsiProc* map */
+		OsiProcs *ps = NULL;		/**< the actual OsiProc structs pointed to by proc_map are contained here */
+		static OsiProcs *OsiProcsSubset(ProcMap *, PidSet *);
+		static OsiProc *OsiProcCopy(OsiProc *from, OsiProc *to);
+};
+#else
+typedef struct ProcState ProcState;
+#endif
+
+
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+extern ProcState pstate;
+
+/*!
+ * @brief C wrapper for updating the global process state.
+ */
+void procstate_update(OsiProcs *ps, OsiProcs **in, OsiProcs **out);
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif

--- a/qemu/panda_plugins/osi/osi_types.h
+++ b/qemu/panda_plugins/osi/osi_types.h
@@ -33,4 +33,44 @@ typedef struct osi_modules_struct {
     OsiModule *module;
 } OsiModules;
 
+
+
+/*
+ * Generic inlines for handling OsiProc, OsiProcs structs.
+ * It is left to the OS-specific modules to use them or not.
+ */
+
+/*! @brief Frees an OsiProc struct. */
+static inline void free_osiproc_g(OsiProc *p) {
+	if (p == NULL) return;
+	g_free(p->name);
+	g_free(p);
+	return;
+}
+
+/*! @brief Frees an OsiProcs struct. */
+static inline void free_osiprocs_g(OsiProcs *ps) {
+	uint32_t i;
+	if (ps == NULL) return;
+	for (i=0; i< ps->num; i++) {
+		g_free(ps->proc[i].name);
+	}
+	g_free(ps->proc);
+	g_free(ps);
+	return;
+}
+
+/*! @brief Copies an OsiProc struct. Returns a pointer to the destination location.
+ *
+ * @note Members of `to` struct must have been freed to avoid memory leaks.
+ */
+static inline OsiProc *copy_osiproc_g(OsiProc *from, OsiProc *to) {
+	if (from == NULL) return NULL;
+	if (to == NULL) to = (OsiProc *)g_malloc0(sizeof(OsiProc));
+
+	memcpy(to, from, sizeof(OsiProc));
+	to->name = g_strdup(from->name);
+	to->pages = NULL; // OsiPage - TODO
+	return to;
+}
 #endif


### PR DESCRIPTION
Plugins can register to be notified at the creation/destruction of processes (`on_new_process`, `on_finished_process` callbacks). 

Disabled by default. To enable add "-DOSI_PROC_EVENTS" in the extra cflags in build.sh.