### PR TITLE
Apigen script fix. All inlines in _ext.h are now static.

### DIFF
--- a/scripts/apigen.py
+++ b/scripts/apigen.py
@@ -79,8 +79,8 @@ def generate_code(functions, module, includes):
         fn_args = ",".join(fn_args_list)
         code+= "typedef " + fn_rtype + "(*" + fn_name + "_t)(" + fn_args_with_types + ");\n"
         code+= "static " + fn_name + "_t __" + fn_name + " = NULL;\n"
-        code += "inline " + fn_rtype + " " + fn_name + "(" + fn_args_with_types + ");\n"
-        code += "inline " + fn_rtype + " " + fn_name + "(" + fn_args_with_types + "){\n"
+        code += "static inline " + fn_rtype + " " + fn_name + "(" + fn_args_with_types + ");\n"
+        code += "static inline " + fn_rtype + " " + fn_name + "(" + fn_args_with_types + "){\n"
         code += "    assert(__" + fn_name + ");\n"
         code += "    return __" + fn_name + "(" + fn_args + ");\n"
         code += "}\n"
@@ -96,8 +96,8 @@ def generate_code(functions, module, includes):
  } \\
 }
 """
-    code += "inline bool init_%s_api(void);" % module
-    code += "inline bool init_%s_api(void){" % module
+    code += "static inline bool init_%s_api(void);" % module
+    code += "static inline bool init_%s_api(void){" % module
 
 
     code += """


### PR DESCRIPTION
This patch changes the generation of plugin API header files to allo making API calls from different source files of the same plugin.
Because of the use of static variables, each source file that wishes to make an API call has to seperately call the API initializer.

Explanation:
The `*_ext.h` headers generated by `apigen.py` contained one static function pointer per API call as well as (non-static) inline functions that initialize and use the pointer. Because the inlines were non-static, they weren't accessing the proper "instance" of the function pointer. The effect was that API calls could be made only from the main source file of each plugin.
By making the inlines static as well, the scoping error is fixed and they operate on the appropriate function pointer "instance".
