### PR TITLE
Fixed free-before-malloc error.

### DIFF
--- a/qemu/panda_plugins/osi_winxpsp3x86/osi_winxpsp3x86.cpp
+++ b/qemu/panda_plugins/osi_winxpsp3x86/osi_winxpsp3x86.cpp
@@ -265,7 +265,19 @@ void on_get_current_process(CPUState *env, OsiProc **out_p) {
         Since I'm using KTHREAD_KPROC_OFF as an ETHREAD, check to make
         sure this is a kernel thread that has an associated user process.
     */
-    if (is_valid_process(env, eproc)) {
+    while (!is_valid_process(env,eproc))
+    {
+        eproc = get_next_proc(env, eproc);
+
+        if (!eproc) break;
+    }
+
+    if (!eproc)
+    {
+        p->name = NULL; //free_osiproc still has to work properly
+    }
+    else
+    {
         fill_osiproc(env, p, eproc);
     }
 
@@ -350,7 +362,7 @@ void on_get_libraries(CPUState *env, OsiProc *p, OsiModules **out_ms) {
 
 void on_free_osiproc(OsiProc *p) {
     if (!p) return;
-    free(p->name);
+    if (p->name) free(p->name);
     free(p);
 }
 


### PR DESCRIPTION
Fixed bug where free() would produce an error because of my conditional statement in on_get_current_process(). If the condition was false, then "name" in fill_osiproc() would never get allocated any memory, resulting in a free-before-malloc error.

Also made sure each of my branches was up-to-date with the master branch.