### PR TITLE
linux file descriptor to file name resolution

### DIFF
--- a/docs/compile.md
+++ b/docs/compile.md
@@ -59,6 +59,21 @@ svn checkout http://llvm.org/svn/llvm-project/clang-tools-extra/tags/RELEASE_33/
 cd -
 ```
 
+<!-- Note: Maybe the patch should be copied inside the PANDA repository, or in a gist. -->
+
+If you are working with g++-4.9, you will also need to
+[patch clang](http://reviews.llvm.org/rL201729) to provide `max_align_t`.
+Otherwise building of some plugins will fail.
+
+```
+export CLANG_PATCH=http://reviews.llvm.org/file/data/sw37fgtbupwhetydgazl/PHID-FILE-wprxzvc5yn4ylp7xwt6t/201729.diff
+cd llvm/tools/clang
+wget -O - "$CLANG_PATCH" | patch -p2 -F3
+unset CLANG_PATCH
+cd -
+```
+
+
 Now, compile LLVM. For a **debug build** (REALLY slow), use the following command:
 
 ```

--- a/qemu/panda_plugins/osi_linux/kernel_structs.md
+++ b/qemu/panda_plugins/osi_linux/kernel_structs.md
@@ -12,28 +12,47 @@ Sketch of some of the structures used for Linux OS introspection. Only relevant 
             unsigned long vm\_start;     /\* start address within vm_mm \*/
             unsigned long vm\_end;       /\* first byte after our end within vm_mm \*/
             unsigned long vm\_flags;     /\* RWXS flags \*/
-            struct file \*vm\_file {{     /\* file we map to (can be NULL): [fs.h][file], pp471 */
+            struct file \*vm\_file {{     /\* file we map to (can be NULL): [fs.h][file], pp471 \*/
                 struct path f\_path {{   /\* not pointer!: [path.h][path] \*/
-                    struct vfsmount \*mnt {{    /\* mounted fs containing file: [mount.h][vfsmount] \*/
-                        struct dentry *mnt_mountpoint; /\* dentry of mountpoint: [dcache.h][dentry], pp475 \*/
-                        struct dentry *mnt_root; /\* root of the mounted tree: [dcache.h][dentry], pp475 \*/
+                    struct vfsmount \*mnt {{    /\* mounted fs containing file: [mount.h][vfsmount], pp486 \*/
+                        struct vfsmount \*mnt_parent;
+                        struct dentry \*mnt_mountpoint; /\* dentry of mountpoint: [dcache.h][dentry], pp475 \*/
+                        struct dentry \*mnt_root; /\* root of the mounted tree: [dcache.h][dentry], pp475 \*/
                     }};
                     struct dentry \*dentry {{    /\* where file is located on fs: [dcache.h][dentry], pp475 \*/
-                        struct qstr d_name {{   /\* not pointer!: [dcache.h][qstr] \*/
+                        struct qstr d\_name {{   /\* not pointer!: [dcache.h][qstr] \*/
                         	unsigned int len;
                             const unsigned char \*name;
                         }};
                         unsigned char d\_iname[DNAME\_INLINE\_LEN]; /\* should not be used directly! when the name is small enough, d_name->name will point here. \*/  
                     }}; /\* dentry \*/
                 }}; /\* path /*
-                #define f\_dentry f\_path.dentry  /\* pseudo-member \*/
-                #define f\_vfsmnt f\_path.mnt     /\* pseudo-member \*/
             }}; /\* file \*/
         }}; /\* vm\_area\_struct \*/
     }}; /\* mm\_struct \*/
+    struct files\_struct \*files {{ /\* open files information: [fdtable.h][files_struct], ppXXX \*/
+        struct fdtable *fdt {{   /\* ??? this may point to fdtab -- VERIFY : [fdtable.h][fdtable] \*/
+            struct file **fd {{  /\* current fd array: [XXX][XXX] \*/
+            }};
+        }};
+        struct fdtable fdtab {{   /\* not pointer!: [fdtable.h][fdtable] \*/
+            struct file **fd {{  /\* current fd array: [XXX][XXX] \*/
+            }};
+        }};
+    }}; /\* files\_struct \*/
 } /\* task\_struct \*/
 </pre></big>
 
+<!-- fdt seems to point to fdtab in general. for a few tasks it doesn't.
+see
+
+print the tasks where fdt does not point to fdtab:
+grep lul f  | grep '0$' | awk '{print $3}' | sort | uniq -c
+
+see if for any of these tasks, fdt points to fdtab at some point:
+for t in $(grep lul f  | grep '0$' | awk '{print $3}' | sort | uniq); do grep  "lul.*$t.*1$" f; done
+
+-->
 
 [task_struct]: https://github.com/torvalds/linux/blob/v3.2/include/linux/sched.h#L1220
 [mm_struct]: https://github.com/torvalds/linux/blob/v3.2/include/linux/mm_types.h#L289
@@ -43,6 +62,8 @@ Sketch of some of the structures used for Linux OS introspection. Only relevant 
 [vfsmount]: https://github.com/torvalds/linux/blob/v3.2/include/linux/mount.h#L55
 [dentry]: https://github.com/torvalds/linux/blob/v3.2/include/linux/dcache.h#L116
 [qstr]: https://github.com/torvalds/linux/blob/v3.2/include/linux/dcache.h#L35
+[files_struct]: https://github.com/torvalds/linux/blob/v3.2/include/linux/fdtable.h#XXX
+[fdtable]: https://github.com/torvalds/linux/blob/v3.2/include/linux/fdtable.h#XXX
 
 
 # The kernel task list

--- a/qemu/panda_plugins/osi_linux/kernelinfo.conf
+++ b/qemu/panda_plugins/osi_linux/kernelinfo.conf
@@ -1,5 +1,5 @@
-[debian-3.2.63-i686]
-name = #1 Debian 3.2.63-2+deb7u1 i686
+[debian-3.2.65-i686]
+name = #1 Debian 3.2.65-1+deb7u1 i686
 task.size = 1000
 #task.init_addr = 0xC1397480
 task.init_addr = 3241768064
@@ -17,6 +17,7 @@ task.real_cred_offset = 460
 task.cred_offset = 464
 task.comm_offset = 472
 task.comm_size = 16
+task.files_offset = 636
 cred.uid_offset = 4
 cred.gid_offset = 8
 cred.euid_offset = 20
@@ -31,10 +32,16 @@ vma.vm_mm_offset = 0
 vma.vm_start_offset = 4
 vma.vm_end_offset = 8
 vma.vm_next_offset = 12
-vma.vm_file_offset = 76
 vma.vm_flags_offset = 24
-fs.f_dentry_offset = 12
-fs.f_path_offset = 8
+vma.vm_file_offset = 76
+fs.f_path_dentry_offset = 12
+fs.f_path_mnt_offset = 8
+fs.mnt_parent_offset = 8
+fs.mnt_mountpoint_offset = 12
+fs.mnt_root_offset = 16
+fs.fdt_offset = 4
+fs.fdtab_offset = 8
+fs.fd_offset = 4
 fs.d_name_offset = 20
 fs.d_iname_offset = 36
 fs.d_parent_offset = 16

--- a/qemu/panda_plugins/osi_linux/osi_linux.cpp
+++ b/qemu/panda_plugins/osi_linux/osi_linux.cpp
@@ -3,8 +3,8 @@
  * @brief PANDA Operating System Introspection for Linux.
  *
  * @author Manolis Stamatogiannakis <manolis.stamatogiannakis@vu.nl>
- * @copyright   This work is licensed under the terms of the GNU GPL, version 2.
- *              See the COPYING file in the top-level directory. 
+ * @copyright This work is licensed under the terms of the GNU GPL, version 2.
+ * See the COPYING file in the top-level directory.
  */
 extern "C" {
 #include "config.h"
@@ -22,8 +22,8 @@ extern "C" {
 #include <stdlib.h>
 #include <errno.h>
 
-#include "utils/kernelinfo/kernelinfo.h"    /* must come after cpu.h, glib.h */
-#include "osi_linux.h"                      /* must come after kernelinfo.h */
+#include "utils/kernelinfo/kernelinfo.h"	/* must come after cpu.h, glib.h */
+#include "osi_linux.h"						/* must come after kernelinfo.h */
 }
 
 
@@ -82,9 +82,7 @@ static char *get_file_name(CPUState *env, PTR file_struct) {
 }
 
 /**
- * @brief Resolves a file descriptor and returns its full pathname.
- * NULL is returned for file descriptors that can't be resolved
- * (e.g. network sockets).
+ * @brief Resolves a file struct and returns its full pathname.
  */
 static char *get_fd_name(CPUState *env, PTR task_struct, int fd) {
 	PTR files = get_files(env, task_struct);
@@ -109,11 +107,11 @@ static char *get_fd_name(CPUState *env, PTR task_struct, int fd) {
  * @brief Fills an OsiProc struct.
  */
 static void fill_osiproc(CPUState *env, OsiProc *p, PTR task_addr) {
-    p->offset = task_addr;  // XXX: Not sure what this is. Storing task_addr here seems logical.
-    p->name = get_name(env, task_addr, p->name);
-    p->pid = get_pid(env, task_addr);
-    p->ppid = get_real_parent_pid(env, task_addr);
-	p->pages = NULL; // OsiPage - TODO
+	p->offset = task_addr;	// XXX: Not sure what this is. Storing task_addr here seems logical.
+	p->name = get_name(env, task_addr, p->name);
+	p->pid = get_pid(env, task_addr);
+	p->ppid = get_real_parent_pid(env, task_addr);
+	p->pages = NULL;		// OsiPage - TODO
 
 	panda_memory_errors = 0;
 	p->asid = get_pgd(env, task_addr);
@@ -127,43 +125,43 @@ static void fill_osiproc(CPUState *env, OsiProc *p, PTR task_addr) {
  * @brief Fills an OsiModule struct.
  */
 static void fill_osimodule(CPUState *env, OsiModule *m, PTR vma_addr) {
-    target_ulong vma_start, vma_end;
-    PTR vma_vm_file;
-    PTR vma_dentry;
-    PTR mm_addr, start_brk, brk, start_stack;
+	target_ulong vma_start, vma_end;
+	PTR vma_vm_file;
+	PTR vma_dentry;
+	PTR mm_addr, start_brk, brk, start_stack;
 
-    vma_start = get_vma_start(env, vma_addr);
-    vma_end = get_vma_end(env, vma_addr);
-    vma_vm_file = get_vma_vm_file(env, vma_addr);
+	vma_start = get_vma_start(env, vma_addr);
+	vma_end = get_vma_end(env, vma_addr);
+	vma_vm_file = get_vma_vm_file(env, vma_addr);
 
-    // Fill everything but m->name and m->file.
-    m->offset = vma_addr;   // XXX: Not sure what this is. Storing vma_addr here seems logical.
-    m->base = vma_start;
-    m->size = vma_end - vma_start;
+	// Fill everything but m->name and m->file.
+	m->offset = vma_addr;	// XXX: Not sure what this is. Storing vma_addr here seems logical.
+	m->base = vma_start;
+	m->size = vma_end - vma_start;
 
-    if (vma_vm_file != (PTR)NULL) {     // Memory area is mapped from a file.
-        vma_dentry = get_vma_dentry(env, vma_addr);
+	if (vma_vm_file != (PTR)NULL) {	 // Memory area is mapped from a file.
+		vma_dentry = get_vma_dentry(env, vma_addr);
 		m->file = read_dentry_name(env, vma_dentry);
-        m->name = g_strrstr (m->file, "/");
-        if (m->name != NULL) m->name = g_strdup(m->name + 1);
-    }
-    else {                              // Other memory areas.
-        mm_addr = get_vma_vm_mm(env, vma_addr);
-        start_brk = get_mm_start_brk(env, mm_addr);
-        brk = get_mm_brk(env, mm_addr);
-        start_stack = get_mm_start_stack(env, mm_addr);
+		m->name = g_strrstr (m->file, "/");
+		if (m->name != NULL) m->name = g_strdup(m->name + 1);
+	}
+	else {					// Other memory areas.
+		mm_addr = get_vma_vm_mm(env, vma_addr);
+		start_brk = get_mm_start_brk(env, mm_addr);
+		brk = get_mm_brk(env, mm_addr);
+		start_stack = get_mm_start_stack(env, mm_addr);
 
-        m->file = NULL;
-        if (vma_start <= start_brk && vma_end >= brk) {
-            m->name = g_strdup("[heap]");
-        }
-        else if (vma_start <= start_stack && vma_end >= start_stack) {
-            m->name = g_strdup("[stack]");
-        }
-        else {
-            m->name = g_strdup("[???]");
-        }
-    }
+		m->file = NULL;
+		if (vma_start <= start_brk && vma_end >= brk) {
+			m->name = g_strdup("[heap]");
+		}
+		else if (vma_start <= start_stack && vma_end >= start_stack) {
+			m->name = g_strdup("[stack]");
+		}
+		else {
+			m->name = g_strdup("[???]");
+		}
+	}
 
 #if (OSI_LINUX_TEST)
 	LOG_INFO(TARGET_FMT_PTR ":" TARGET_FMT_PTR ":" TARGET_FMT_PID "p:%s:%s", m->offset, m->base, NPAGES(m->size), m->name, m->file);
@@ -171,7 +169,7 @@ static void fill_osimodule(CPUState *env, OsiModule *m, PTR vma_addr) {
 }
 
 
-                                                                                                                    
+
 /* ******************************************************************
  PPP Callbacks
 ****************************************************************** */
@@ -180,50 +178,50 @@ static void fill_osimodule(CPUState *env, OsiModule *m, PTR vma_addr) {
  * @brief PPP callback to retrieve current process info for the running OS.
  */
 void on_get_current_process(CPUState *env, OsiProc **out_p) {
-    OsiProc *p;
-    PTR ts;
-    
-    p = (OsiProc *)g_malloc0(sizeof(OsiProc));
-    ts = get_task_struct(env, (_ESP & THREADINFO_MASK));
-    fill_osiproc(env, p, ts);
+	OsiProc *p;
+	PTR ts;
 
-    *out_p = p;
+	p = (OsiProc *)g_malloc0(sizeof(OsiProc));
+	ts = get_task_struct(env, (_ESP & THREADINFO_MASK));
+	fill_osiproc(env, p, ts);
+
+	*out_p = p;
 }
 
 /**
  * @brief PPP callback to retrieve process list from the running OS.
  */
 void on_get_processes(CPUState *env, OsiProcs **out_ps) {
-    PTR ts_first, ts_current;
-    OsiProcs *ps;
-    OsiProc *p;
-    uint32_t ps_capacity = 16;
+	PTR ts_first, ts_current;
+	OsiProcs *ps;
+	OsiProc *p;
+	uint32_t ps_capacity = 16;
 
-    ts_first = ts_current = get_task_struct(env, (_ESP & THREADINFO_MASK));
-    if (ts_current == (PTR)NULL) goto error0;
+	ts_first = ts_current = get_task_struct(env, (_ESP & THREADINFO_MASK));
+	if (ts_current == (PTR)NULL) goto error0;
 
-    // When thread_group points to itself, the task_struct belongs to a thread
-    // (see kernel_structs.md for details). This will trigger an infinite loop
-    // in the traversal loop.
-    // Following next will lead us to a task_struct belonging to a process and
-    // help avoid the condition.
-    if (ts_current+ki.task.thread_group_offset != get_thread_group(env, ts_current)) {
-        ts_first = ts_current = get_task_struct_next(env, ts_current);
-    }
+	// When thread_group points to itself, the task_struct belongs to a thread
+	// (see kernel_structs.md for details). This will trigger an infinite loop
+	// in the traversal loop.
+	// Following next will lead us to a task_struct belonging to a process and
+	// help avoid the condition.
+	if (ts_current+ki.task.thread_group_offset != get_thread_group(env, ts_current)) {
+		ts_first = ts_current = get_task_struct_next(env, ts_current);
+	}
 
-    ps = (OsiProcs *)g_malloc0(sizeof(OsiProcs));
-    ps->proc = g_new(OsiProc, ps_capacity);
-    do {
-        if (ps->num == ps_capacity) {
-            ps_capacity *= 2;
-            ps->proc = g_renew(OsiProc, ps->proc, ps_capacity);
-        }
+	ps = (OsiProcs *)g_malloc0(sizeof(OsiProcs));
+	ps->proc = g_new(OsiProc, ps_capacity);
+	do {
+		if (ps->num == ps_capacity) {
+			ps_capacity *= 2;
+			ps->proc = g_renew(OsiProc, ps->proc, ps_capacity);
+		}
 
-        p = &ps->proc[ps->num++];
+		p = &ps->proc[ps->num++];
 
-        // Garbage in p->name will cause fill_osiproc() to segfault.
-        memset(p, 0, sizeof(OsiProc));
-        fill_osiproc(env, p, ts_current);
+		// Garbage in p->name will cause fill_osiproc() to segfault.
+		memset(p, 0, sizeof(OsiProc));
+		fill_osiproc(env, p, ts_current);
 
 #if 0
 		/*********************************************************/
@@ -237,108 +235,108 @@ void on_get_processes(CPUState *env, OsiProcs **out_ps) {
 		/*********************************************************/
 #endif
 
-        ts_current = get_task_struct_next(env, ts_current);
-    } while(ts_current != (PTR)NULL && ts_current != ts_first);
+		ts_current = get_task_struct_next(env, ts_current);
+	} while(ts_current != (PTR)NULL && ts_current != ts_first);
 
-    // memory read error
-    if (ts_current == (PTR)NULL) goto error1;
+	// memory read error
+	if (ts_current == (PTR)NULL) goto error1;
 
-    *out_ps = ps;
-    return;
+	*out_ps = ps;
+	return;
 
 error1:
-    do {
-        ps->num--;
-        g_free(ps->proc[ps->num].name);
-    } while (ps->num != 0);
-    g_free(ps->proc);
-    g_free(ps);
+	do {
+		ps->num--;
+		g_free(ps->proc[ps->num].name);
+	} while (ps->num != 0);
+	g_free(ps->proc);
+	g_free(ps);
 error0:
-    *out_ps = NULL;
-    return;
+	*out_ps = NULL;
+	return;
 }
 
 /**
  * @brief PPP callback to retrieve OsiModules from the running OS.
  *
- * Current implementation returns all the memory areas  mapped by the
+ * Current implementation returns all the memory areas mapped by the
  * process and the files they were mapped from. Libraries that have
  * many mappings will appear multiple times.
  *
  * @todo Remove duplicates from results.
  */
 void on_get_libraries(CPUState *env, OsiProc *p, OsiModules **out_ms) {
-    PTR ts_first, ts_current;
-    target_ulong current_pid;
-    OsiModules *ms;
-    OsiModule *m;
-    uint32_t ms_capacity = 16;
+	PTR ts_first, ts_current;
+	target_ulong current_pid;
+	OsiModules *ms;
+	OsiModule *m;
+	uint32_t ms_capacity = 16;
 
-    PTR vma_first, vma_current;
+	PTR vma_first, vma_current;
 
-    // Find the process with the indicated pid.
-    ts_first = ts_current =  get_task_struct(env, (_ESP & THREADINFO_MASK));
-    if (ts_current == (PTR)NULL) goto error0;
+	// Find the process with the indicated pid.
+	ts_first = ts_current = get_task_struct(env, (_ESP & THREADINFO_MASK));
+	if (ts_current == (PTR)NULL) goto error0;
 
-    do {
-        if ((current_pid = get_pid(env, ts_current)) == p->pid) break;
-        ts_current = get_task_struct_next(env, ts_current);
-    } while(ts_current != (PTR)NULL && ts_current != ts_first);
+	do {
+		if ((current_pid = get_pid(env, ts_current)) == p->pid) break;
+		ts_current = get_task_struct_next(env, ts_current);
+	} while(ts_current != (PTR)NULL && ts_current != ts_first);
 
-    // memory read error or process not found
-    if (ts_current == (PTR)NULL || current_pid != p->pid) goto error0;
+	// memory read error or process not found
+	if (ts_current == (PTR)NULL || current_pid != p->pid) goto error0;
 
-    // Read the module info for the process.
-    vma_first = vma_current = get_vma_first(env, ts_current);
-    if (vma_current == (PTR)NULL) goto error0;
+	// Read the module info for the process.
+	vma_first = vma_current = get_vma_first(env, ts_current);
+	if (vma_current == (PTR)NULL) goto error0;
 
-    ms = (OsiModules *)g_malloc0(sizeof(OsiModules));
-    ms->module = g_new(OsiModule, ms_capacity);
-    do {
-        if (ms->num == ms_capacity) {
-            ms_capacity *= 2;
-            ms->module = g_renew(OsiModule, ms->module, ms_capacity);
-        }
+	ms = (OsiModules *)g_malloc0(sizeof(OsiModules));
+	ms->module = g_new(OsiModule, ms_capacity);
+	do {
+		if (ms->num == ms_capacity) {
+			ms_capacity *= 2;
+			ms->module = g_renew(OsiModule, ms->module, ms_capacity);
+		}
 
-        m = &ms->module[ms->num++];
-        memset(m, 0, sizeof(OsiModule));
-        fill_osimodule(env, m, vma_current);
+		m = &ms->module[ms->num++];
+		memset(m, 0, sizeof(OsiModule));
+		fill_osimodule(env, m, vma_current);
 
-        vma_current = get_vma_next(env, vma_current);
-    } while(vma_current != (PTR)NULL && vma_current != vma_first);
+		vma_current = get_vma_next(env, vma_current);
+	} while(vma_current != (PTR)NULL && vma_current != vma_first);
 
-    *out_ms = ms;
-    return;
+	*out_ms = ms;
+	return;
 
 error0:
-    *out_ms = NULL;
-    return;
+	*out_ms = NULL;
+	return;
 }
 
 /**
  * @brief PPP callback to free memory allocated for an OsiProc struct.
  */
 void on_free_osiproc(OsiProc *p) {
-    if (p == NULL) return;
-    g_free(p->name);
-    g_free(p);
-    return;
+	if (p == NULL) return;
+	g_free(p->name);
+	g_free(p);
+	return;
 }
 
 /**
  * @brief PPP callback to free memory allocated for an OsiProcs struct.
  */
 void on_free_osiprocs(OsiProcs *ps) {
-    uint32_t i;
+	uint32_t i;
 
-    if (ps == NULL) return;
+	if (ps == NULL) return;
 
-    for (i=0; i< ps->num; i++) {
-        g_free(ps->proc[i].name);
-    }
-    g_free(ps->proc);
-    g_free(ps);
-    return;
+	for (i=0; i< ps->num; i++) {
+		g_free(ps->proc[i].name);
+	}
+	g_free(ps->proc);
+	g_free(ps);
+	return;
 }
 
 
@@ -368,17 +366,17 @@ make_name:
  * @brief PPP callback to free memory allocated for an OsiModules struct.
  */
 void on_free_osimodules(OsiModules *ms) {
-    uint32_t i;
+	uint32_t i;
 
-    if (ms == NULL) return;
+	if (ms == NULL) return;
 
-    for (i=0; i< ms->num; i++) {
-        g_free(ms->module[i].name);
-        g_free(ms->module[i].file);
-    }
-    g_free(ms->module);
-    g_free(ms);
-    return;
+	for (i=0; i< ms->num; i++) {
+		g_free(ms->module[i].name);
+		g_free(ms->module[i].file);
+	}
+	g_free(ms->module);
+	g_free(ms);
+	return;
 }
 
 
@@ -391,29 +389,29 @@ void on_free_osimodules(OsiModules *ms) {
  * @brief Fills an OsiProc struct.
  */
 int vmi_pgd_changed(CPUState *env, target_ulong oldval, target_ulong newval) {
-    OsiProcs *ps;
-    OsiModules *ms;
-    uint32_t i;
+	OsiProcs *ps;
+	OsiModules *ms;
+	uint32_t i;
 
-    if (!_IN_KERNEL) {
-        // This shouldn't ever happen, as PGD is updated only in kernel mode.
-        LOG_ERR("Can't do introspection in user mode.");
-        goto error;
-    }
+	if (!_IN_KERNEL) {
+		// This shouldn't ever happen, as PGD is updated only in kernel mode.
+		LOG_ERR("Can't do introspection in user mode.");
+		goto error;
+	}
 
-    LOG_INFO("------------------------------------------------");
-    on_get_processes(env, &ps);
-    for (i=0; i< ps->num; i++) {
-        on_get_libraries(env, &ps->proc[i], &ms);
-        on_free_osimodules(ms);
-    }
-    on_free_osiprocs(ps);
-    LOG_INFO("------------------------------------------------");
-    
-    return 0;
+	LOG_INFO("------------------------------------------------");
+	on_get_processes(env, &ps);
+	for (i=0; i< ps->num; i++) {
+		on_get_libraries(env, &ps->proc[i], &ms);
+		on_free_osimodules(ms);
+	}
+	on_free_osiprocs(ps);
+	LOG_INFO("------------------------------------------------");
+	
+	return 0;
 
 error:
-    return -1;
+	return -1;
 }
 #endif
 
@@ -429,43 +427,43 @@ error:
 bool init_plugin(void *self) {
 #if defined(TARGET_I386) || defined(TARGET_ARM)
 #if (OSI_LINUX_TEST)
-    panda_cb pcb = { .after_PGD_write = vmi_pgd_changed };
+	panda_cb pcb = { .after_PGD_write = vmi_pgd_changed };
 #endif
 
-    // Read the name of the kernel configuration to use.
-    panda_arg_list *plugin_args = panda_get_args(PLUGIN_NAME);
-    char *kconf_file = g_strdup(panda_parse_string(plugin_args, "kconf_file", DEFAULT_KERNELINFO_FILE));
-    char *kconf_group = g_strdup(panda_parse_string(plugin_args, "kconf_group", DEFAULT_KERNELINFO_GROUP));
-    panda_free_args(plugin_args);
+	// Read the name of the kernel configuration to use.
+	panda_arg_list *plugin_args = panda_get_args(PLUGIN_NAME);
+	char *kconf_file = g_strdup(panda_parse_string(plugin_args, "kconf_file", DEFAULT_KERNELINFO_FILE));
+	char *kconf_group = g_strdup(panda_parse_string(plugin_args, "kconf_group", DEFAULT_KERNELINFO_GROUP));
+	panda_free_args(plugin_args);
 
-    // Load kernel offsets.
-    if (read_kernelinfo(kconf_file, kconf_group, &ki) != 0) {
-        LOG_ERR("Failed to read kernel info from group \"%s\" of file \"%s\".", kconf_group, kconf_file);
-        goto error;
-    }
-    LOG_INFO("Read kernel info from group \"%s\" of file \"%s\".", kconf_group, kconf_file);
-    g_free(kconf_file);
-    g_free(kconf_group);
+	// Load kernel offsets.
+	if (read_kernelinfo(kconf_file, kconf_group, &ki) != 0) {
+		LOG_ERR("Failed to read kernel info from group \"%s\" of file \"%s\".", kconf_group, kconf_file);
+		goto error;
+	}
+	LOG_INFO("Read kernel info from group \"%s\" of file \"%s\".", kconf_group, kconf_file);
+	g_free(kconf_file);
+	g_free(kconf_group);
 
 #if (OSI_LINUX_TEST)
-    panda_register_callback(self, PANDA_CB_VMI_PGD_CHANGED, pcb);
+	panda_register_callback(self, PANDA_CB_VMI_PGD_CHANGED, pcb);
 #else
-    PPP_REG_CB("osi", on_get_current_process, on_get_current_process);
-    PPP_REG_CB("osi", on_get_processes, on_get_processes);
-    PPP_REG_CB("osi", on_free_osiproc, on_free_osiproc);
-    PPP_REG_CB("osi", on_free_osiprocs, on_free_osiprocs);
-    PPP_REG_CB("osi", on_get_libraries, on_get_libraries);
-    PPP_REG_CB("osi", on_free_osimodules, on_free_osimodules);
+	PPP_REG_CB("osi", on_get_current_process, on_get_current_process);
+	PPP_REG_CB("osi", on_get_processes, on_get_processes);
+	PPP_REG_CB("osi", on_free_osiproc, on_free_osiproc);
+	PPP_REG_CB("osi", on_free_osiprocs, on_free_osiprocs);
+	PPP_REG_CB("osi", on_get_libraries, on_get_libraries);
+	PPP_REG_CB("osi", on_free_osimodules, on_free_osimodules);
 #endif
-    
-    LOG_INFO(PLUGIN_NAME " initialization complete.");
-    return true;
+
+	LOG_INFO(PLUGIN_NAME " initialization complete.");
+	return true;
 #else
-    goto error;
+	goto error;
 #endif
 
 error:
-    return false;
+	return false;
 }
 
 /**
@@ -473,9 +471,9 @@ error:
  */
 void uninit_plugin(void *self) {
 #if defined(TARGET_I386) || defined(TARGET_ARM)
-    // Nothing to do...
+	// Nothing to do...
 #endif
-    return;
+	return;
 }
 
 /* vim:set tabstop=4 softtabstop=4 noexpandtab */

--- a/qemu/panda_plugins/osi_linux/osi_linux.h
+++ b/qemu/panda_plugins/osi_linux/osi_linux.h
@@ -12,8 +12,8 @@
  *
  *
  * @author Manolis Stamatogiannakis <manolis.stamatogiannakis@vu.nl>
- * @copyright   This work is licensed under the terms of the GNU GPL, version 2.
- *              See the COPYING file in the top-level directory. 
+ * @copyright This work is licensed under the terms of the GNU GPL, version 2.
+ * See the COPYING file in the top-level directory.
  */
 #ifndef OSI_LINUX_H
 #define OSI_LINUX_H
@@ -26,7 +26,7 @@
  * @brief Pointer type of the guest VM.
  *
  * @note This definition implies that the guest VM pointer size matches the
- * size of unsigned long of the target processor. This is a reasonable 
+ * size of unsigned long of the target processor. This is a reasonable
  * assumption to make -- at least in the context of a research prototype.
  */
 #define PTR target_ulong
@@ -73,9 +73,9 @@
  * @brief Platform specific macro for retrieving the page directory address.
  */
 #if defined(TARGET_I386)
-#define _PGD    (env->cr[3])
+#define _PGD		(env->cr[3])
 #elif defined(TARGET_ARM)
-#define _PGD    (env->cp15.c2_base0 & env->cp15.c2_base_mask)
+#define _PGD		(env->cp15.c2_base0 & env->cp15.c2_base_mask)
 #else
 #error	"_PGD macro not defined for target architecture."
 #endif
@@ -90,7 +90,7 @@
 /* check for supervisor mode in the Current Program Status register */
 #define _IN_KERNEL ((env->uncached_cpsr & CPSR_M) == ARM_CPU_MODE_SVC)
 #else
-#error  "_IN_KERNEL macro not defined for target architecture."
+#error	"_IN_KERNEL macro not defined for target architecture."
 #endif
 
 #define LOG_ERR(fmt, args...) fprintf(stderr, "ERROR(%s:%s): " fmt "\n", __FILE__, __func__, ## args)
@@ -109,33 +109,33 @@ extern int panda_memory_errors;
  * @brief IMPLEMENT_OFFSET_GET is a macro for generating uniform
  * inlines for retrieving data based on a location+offset.
  */
-#define IMPLEMENT_OFFSET_GET(_name, _paramName, _retType, _offset, _errorRetValue)                        \
-static inline _retType _name(CPUState* env, PTR _paramName) {                                             \
-  _retType _t;                                                                                            \
-  if (-1 == panda_virtual_memory_rw(env, _paramName + _offset, (uint8_t *)&_t, sizeof(_retType), 0)) { \
-    panda_memory_errors++;                                                                                \
-    return (_errorRetValue);                                                                              \
-  }                                                                                                       \
-  return (_t);                                                                                            \
+#define IMPLEMENT_OFFSET_GET(_name, _paramName, _retType, _offset, _errorRetValue) \
+static inline _retType _name(CPUState* env, PTR _paramName) { \
+	_retType _t; \
+	if (-1 == panda_virtual_memory_rw(env, _paramName + _offset, (uint8_t *)&_t, sizeof(_retType), 0)) { \
+		panda_memory_errors++; \
+		return (_errorRetValue); \
+	} \
+	return (_t); \
 }
 
 /**
  * @brief IMPLEMENT_OFFSET_GET2L is a macro for generating uniform
  * inlines for retrieving data based on a *(location+offset1) + offset2.
  */
-#define IMPLEMENT_OFFSET_GET2L(_name, _paramName, _retType1, _offset1, _retType2, _offset2, _errorRetValue)   \
-static inline _retType2 _name(CPUState* env, PTR _paramName) {                                                \
-  _retType1 _t1;                                                                                              \
-  _retType2 _t2;                                                                                              \
-  if (-1 == panda_virtual_memory_rw(env, _paramName + _offset1, (uint8_t *)&_t1, sizeof(_retType1), 0)) {  \
-    panda_memory_errors++;                                                                                    \
-    return (_errorRetValue);                                                                                  \
-  }                                                                                                           \
-  if (-1 == panda_virtual_memory_rw(env, _t1 + _offset2, (uint8_t *)&_t2, sizeof(_retType2), 0)) {         \
-    panda_memory_errors++;                                                                                    \
-    return (_errorRetValue);                                                                                  \
-  }                                                                                                           \
-  return (_t2);                                                                                               \
+#define IMPLEMENT_OFFSET_GET2L(_name, _paramName, _retType1, _offset1, _retType2, _offset2, _errorRetValue) \
+static inline _retType2 _name(CPUState* env, PTR _paramName) { \
+	_retType1 _t1; \
+	_retType2 _t2; \
+	if (-1 == panda_virtual_memory_rw(env, _paramName + _offset1, (uint8_t *)&_t1, sizeof(_retType1), 0)) { \
+		panda_memory_errors++; \
+		return (_errorRetValue); \
+	} \
+	if (-1 == panda_virtual_memory_rw(env, _t1 + _offset2, (uint8_t *)&_t2, sizeof(_retType2), 0)) { \
+		panda_memory_errors++; \
+		return (_errorRetValue); \
+	} \
+	return (_t2); \
 }
 
 
@@ -259,7 +259,7 @@ IMPLEMENT_OFFSET_GET2L(get_vma_dentry, vma_struct, PTR, ki.vma.vm_file_offset, P
  * @brief Retrieves the vfsmount dentry associated with a vma_struct.
  *
  * XXX: Reading the vfsmount dentry is required to get the full pathname of files not located in the root fs.
- *			This hasn't been implemented yet...
+ * This hasn't been implemented yet...
  */
 IMPLEMENT_OFFSET_GET2L(get_vma_vfsmount_dentry, vma_struct, PTR, ki.vma.vm_file_offset, PTR, ki.fs.f_path_dentry_offset, 0)
 
@@ -270,7 +270,7 @@ IMPLEMENT_OFFSET_GET(get_files, task_struct, PTR, ki.task.files_offset, 0)
 
 /**
  * @brief Retrieves the array of file structs from the files struct.
- *				The n-th element of the array corresponds to the n-th open fd.
+ * The n-th element of the array corresponds to the n-th open fd.
  */
 IMPLEMENT_OFFSET_GET2L(get_files_fds, files_struct, PTR, ki.fs.fdt_offset, PTR, ki.fs.fd_offset, 0)
 
@@ -310,15 +310,15 @@ IMPLEMENT_OFFSET_GET(get_mnt_root_dentry, vfsmount_struct, PTR, ki.fs.mnt_root_o
 /**
  * @brief Size of the qstr kernel struct. Used to resolve dentry struct to names.
  *
- *  Because the struct is simple with no conditionally defined members,
- *  we choose to not use kernel offsets read from kernelinfo.conf to retrieve it.
+ *	Because the struct is simple with no conditionally defined members,
+ *	we choose to not use kernel offsets read from kernelinfo.conf to retrieve it.
  *
  * @code{.c}
- *  struct qstr {
- *    unsigned int hash;
- *    unsigned int len;
- *    const unsigned char *name;
- *  };
+ *	struct qstr {
+ *		unsigned int hash;
+ *		unsigned int len;
+ *		const unsigned char *name;
+ *	};
  * @endcode
  */
 #define _SIZEOF_QSTR (2*sizeof(target_uint) + sizeof(PTR))
@@ -354,82 +354,82 @@ static inline PTR get_fd_file(CPUState *env, PTR fd_file_array, int n) {
 static inline char *read_dentry_name(CPUState *env, PTR dentry) {
 	char *name = NULL;
 	PTR current_dentry;
-  uint8_t d_name[_SIZEOF_QSTR];
-  int err;
+	uint8_t d_name[_SIZEOF_QSTR];
+	int err;
 
-  // current path component
-  char *pcomp = NULL;
-  target_uint pcomp_length = 0;
-  unsigned int pcomp_capacity = 32;
+	// current path component
+	char *pcomp = NULL;
+	target_uint pcomp_length = 0;
+	unsigned int pcomp_capacity = 32;
 
-  // all path components read so far
-  char **pcomps = NULL;
-  unsigned int pcomps_idx = 0;
-  unsigned int pcomps_capacity = 16;
+	// all path components read so far
+	char **pcomps = NULL;
+	unsigned int pcomps_idx = 0;
+	unsigned int pcomps_capacity = 16;
 
-  // for reversing pcomps
-  char **pcomps_start, **pcomps_end;
+	// for reversing pcomps
+	char **pcomps_start, **pcomps_end;
 
-  pcomp = (char *)g_malloc(pcomp_capacity * sizeof(char));
-  pcomps = (char **)g_malloc(pcomps_capacity * sizeof(char *));
-  do {
+	pcomp = (char *)g_malloc(pcomp_capacity * sizeof(char));
+	pcomps = (char **)g_malloc(pcomps_capacity * sizeof(char *));
+	do {
 		current_dentry = dentry;
 
-    // read d_name qstr
+		// read d_name qstr
 		err = panda_virtual_memory_rw(env, current_dentry + ki.fs.d_name_offset, d_name, _SIZEOF_QSTR, 0);
-    if (-1 == err) goto error;
+		if (-1 == err) goto error;
 
-    // read component
-    pcomp_length = *(target_uint *)(d_name + sizeof(target_uint)) + 1;
-    if (pcomp_capacity < pcomp_length) {
-      pcomp_capacity = pcomp_length;
-      pcomp = (char *)g_realloc(pcomp, pcomp_capacity * sizeof(char));
-    }
-    err = panda_virtual_memory_rw(env, *(PTR *)(d_name + 2*sizeof(target_uint)), (uint8_t *)pcomp, pcomp_length*sizeof(char), 0);
-    if (-1 == err) goto error;
+		// read component
+		pcomp_length = *(target_uint *)(d_name + sizeof(target_uint)) + 1;
+		if (pcomp_capacity < pcomp_length) {
+			pcomp_capacity = pcomp_length;
+			pcomp = (char *)g_realloc(pcomp, pcomp_capacity * sizeof(char));
+		}
+		err = panda_virtual_memory_rw(env, *(PTR *)(d_name + 2*sizeof(target_uint)), (uint8_t *)pcomp, pcomp_length*sizeof(char), 0);
+		if (-1 == err) goto error;
 
-    // copy component
-    if (pcomps_idx == pcomps_capacity - 1) { // -1 leaves room for NULL termination
-      pcomps_capacity *= 2;
-      pcomps = (char **)g_realloc(pcomps, pcomps_capacity * sizeof(char *));
-    }
-    pcomps[pcomps_idx++] = g_strdup(pcomp);
+		// copy component
+		if (pcomps_idx == pcomps_capacity - 1) { // -1 leaves room for NULL termination
+			pcomps_capacity *= 2;
+			pcomps = (char **)g_realloc(pcomps, pcomps_capacity * sizeof(char *));
+		}
+		pcomps[pcomps_idx++] = g_strdup(pcomp);
 
-    // read the parent dentry
+		// read the parent dentry
 		err = panda_virtual_memory_rw(env, current_dentry + ki.fs.d_parent_offset, (uint8_t *)&dentry, sizeof(PTR), 0);
-    if (-1 == err) goto error;
+		if (-1 == err) goto error;
 	} while (dentry != current_dentry);
 
-  // reverse components order
-  g_free(pcomp);
-  pcomps_start = pcomps;
-  pcomps_end = &pcomps[pcomps_idx - 1];
-  while (pcomps_start < pcomps_end) {
-    pcomp = *pcomps_start;
-    *pcomps_start = *pcomps_end;
-    *pcomps_end = pcomp;
-    pcomps_start++;
-    pcomps_end--;
-  }
+	// reverse components order
+	g_free(pcomp);
+	pcomps_start = pcomps;
+	pcomps_end = &pcomps[pcomps_idx - 1];
+	while (pcomps_start < pcomps_end) {
+		pcomp = *pcomps_start;
+		*pcomps_start = *pcomps_end;
+		*pcomps_end = pcomp;
+		pcomps_start++;
+		pcomps_end--;
+	}
 
-  // join components and return
-  pcomps[pcomps_idx] = NULL;      // NULL terminate vector
+	// join components and return
+	pcomps[pcomps_idx] = NULL;			// NULL terminate vector
 	if (dentry == current_dentry) { // Eliminate root directory.
-    pcomps[0][0] = '\0';
-  }
-  name = g_strjoinv("/", pcomps);
-  g_strfreev(pcomps);
+		pcomps[0][0] = '\0';
+	}
+	name = g_strjoinv("/", pcomps);
+	g_strfreev(pcomps);
 
-  return name;
+	return name;
 
 error:
-  LOG_INFO("Error reading d_entry.");
-  panda_memory_errors++;
-  pcomps[pcomps_idx] = NULL;
-  g_free(pcomp);
-  g_strfreev(pcomps);
+	LOG_INFO("Error reading d_entry.");
+	panda_memory_errors++;
+	pcomps[pcomps_idx] = NULL;
+	g_free(pcomp);
+	g_strfreev(pcomps);
 
-  return NULL;
+	return NULL;
 }
 
 /**
@@ -495,25 +495,24 @@ static inline char *read_vfsmount_name(CPUState *env, PTR vfsmount) {
  * This means that we don't have to account for the terminating '\0'.
  */
 static inline char *get_name(CPUState *env, PTR task_struct, char *name) {
-  if (name == NULL) { name = (char *)g_malloc0(ki.task.comm_size * sizeof(char)); }
-  else { name = (char *)g_realloc(name, ki.task.comm_size * sizeof(char)); }
-  if (-1 == panda_virtual_memory_rw(env, task_struct + ki.task.comm_offset, (uint8_t *)name, ki.task.comm_size * sizeof(char), 0)) {
-    panda_memory_errors++;
-    strncpy(name, "N/A", ki.task.comm_size*sizeof(char));
-  }
-  return name;
+	if (name == NULL) { name = (char *)g_malloc0(ki.task.comm_size * sizeof(char)); }
+	else { name = (char *)g_realloc(name, ki.task.comm_size * sizeof(char)); }
+	if (-1 == panda_virtual_memory_rw(env, task_struct + ki.task.comm_offset, (uint8_t *)name, ki.task.comm_size * sizeof(char), 0)) {
+		panda_memory_errors++;
+		strncpy(name, "N/A", ki.task.comm_size*sizeof(char));
+	}
+	return name;
 }
 
 /**
  * @brief Retrieves the address of the following task_struct in the process list.
  */
 static inline PTR get_task_struct_next(CPUState *env, PTR task_struct) {
-  PTR tasks = get_tasks(env, task_struct);
+	PTR tasks = get_tasks(env, task_struct);
 
-  if (!tasks) return (PTR)NULL;
-  else return tasks-ki.task.tasks_offset;
+	if (!tasks) return (PTR)NULL;
+	else return tasks-ki.task.tasks_offset;
 }
 #endif
-
 
 /* vim:set tabstop=4 softtabstop=4 noexpandtab */

--- a/qemu/panda_plugins/osi_linux/osi_linux_int.h
+++ b/qemu/panda_plugins/osi_linux/osi_linux_int.h
@@ -1,0 +1,23 @@
+//  NOTE.  This file is a manually generated spec for the API to this plugin.
+//  It is intended to be consumed by apigen.py.  Actually pycparser is what
+//  consumes it.
+
+//  Other plugin .c, .h, and cpp files SHOULD NOT include this file.
+//  It looks like a real header but its not.  Those typedef voids below are a dead
+//  giveaway.  Those are there to fake out pycparser which, otherwise, would require
+//  lots of code to be pulled in to get definitions for those types, which aren't
+//  necessary for autogenerating code.
+
+//  Please always put the actual prototypes in a separate file, XXX_int_fns.h.
+//  It is fine to #include that file.
+
+//  Also, you CANT put and typedefs or #includes in XXX_int_fns.h as it will bollocks
+//  pycparser.  Unless they are ones that are easy to find like stdint.h.
+//  Just the prototypes, please.
+
+
+typedef void OsiProc;
+typedef void CPUState;
+
+#include "osi_linux_int_fns.h"
+

--- a/qemu/panda_plugins/osi_linux/osi_linux_int.h
+++ b/qemu/panda_plugins/osi_linux/osi_linux_int.h
@@ -1,19 +1,19 @@
-//  NOTE.  This file is a manually generated spec for the API to this plugin.
-//  It is intended to be consumed by apigen.py.  Actually pycparser is what
-//  consumes it.
+// NOTE. This file is a manually generated spec for the API to this plugin.
+// It is intended to be consumed by apigen.py. Actually pycparser is what
+// consumes it.
 
-//  Other plugin .c, .h, and cpp files SHOULD NOT include this file.
-//  It looks like a real header but its not.  Those typedef voids below are a dead
-//  giveaway.  Those are there to fake out pycparser which, otherwise, would require
-//  lots of code to be pulled in to get definitions for those types, which aren't
-//  necessary for autogenerating code.
+// Other plugin .c, .h, and cpp files SHOULD NOT include this file.
+// It looks like a real header but its not. Those typedef voids below are a dead
+// giveaway. Those are there to fake out pycparser which, otherwise, would require
+// lots of code to be pulled in to get definitions for those types, which aren't
+// necessary for autogenerating code.
 
-//  Please always put the actual prototypes in a separate file, XXX_int_fns.h.
-//  It is fine to #include that file.
+// Please always put the actual prototypes in a separate file, XXX_int_fns.h.
+// It is fine to #include that file.
 
-//  Also, you CANT put and typedefs or #includes in XXX_int_fns.h as it will bollocks
-//  pycparser.  Unless they are ones that are easy to find like stdint.h.
-//  Just the prototypes, please.
+// Also, you CANT put and typedefs or #includes in XXX_int_fns.h as it will bollocks
+// pycparser. Unless they are ones that are easy to find like stdint.h.
+// Just the prototypes, please.
 
 
 typedef void OsiProc;
@@ -21,3 +21,4 @@ typedef void CPUState;
 
 #include "osi_linux_int_fns.h"
 
+/* vim:set tabstop=4 softtabstop=4 noexpandtab */

--- a/qemu/panda_plugins/osi_linux/osi_linux_int_fns.h
+++ b/qemu/panda_plugins/osi_linux/osi_linux_int_fns.h
@@ -1,0 +1,10 @@
+#ifndef __OSI_LINUX_INT_FNS_H__
+#define __OSI_LINUX_INT_FNS_H__
+
+// Here we define functions osi_linux provides in addition to
+// the standard osi API.
+
+// resolves an fd to a filename or a made-up name if not a file
+char *osi_linux_resolve_fd(CPUState *env, OsiProc *p, int fd);
+
+#endif

--- a/qemu/panda_plugins/osi_linux/osi_linux_int_fns.h
+++ b/qemu/panda_plugins/osi_linux/osi_linux_int_fns.h
@@ -8,3 +8,5 @@
 char *osi_linux_resolve_fd(CPUState *env, OsiProc *p, int fd);
 
 #endif
+
+/* vim:set tabstop=4 softtabstop=4 noexpandtab */

--- a/qemu/panda_plugins/osi_linux/utils/kernelinfo/kernelinfo.c
+++ b/qemu/panda_plugins/osi_linux/utils/kernelinfo/kernelinfo.c
@@ -3,8 +3,8 @@
  * @brief Retrieves offset information from the running Linux kernel and prints them in the kernel log.
  *
  * @author Manolis Stamatogiannakis <manolis.stamatogiannakis@vu.nl>
- * @copyright   This work is licensed under the terms of the GNU GPL, version 2.
- *              See the COPYING file in the top-level directory. 
+ * @copyright This work is licensed under the terms of the GNU GPL, version 2.
+ * See the COPYING file in the top-level directory.
  */
 #include <linux/module.h>	/* Needed by all modules */
 #include <linux/kernel.h>	/* Needed for KERN_INFO */
@@ -28,12 +28,12 @@
  *
  * E.g. for:
  * struct file {
- *  ...
- *  struct dentry {
- *      struct *vfsmount;
- *      struct *dentry;
- *  }
- *  ...
+ *	...
+ *	struct dentry {
+ *		struct *vfsmount;
+ *		struct *dentry;
+ *	}
+ *	...
  * };
  *
  * Caveat: Because a static buffer is returned, the function
@@ -41,13 +41,13 @@
  */
 #define MAX_MEMBER_NAME 31
 static char *cp_memb(const char *s) {
-    static char memb[MAX_MEMBER_NAME+1];
-    int i;
-    for (i = 0; i<MAX_MEMBER_NAME && s[i]!='\0'; i++) {
-        memb[i] = s[i] == '.' ? '_' : s[i];
-    }
-    memb[i] = 0;
-    return memb;
+	static char memb[MAX_MEMBER_NAME+1];
+	int i;
+	for (i = 0; i<MAX_MEMBER_NAME && s[i]!='\0'; i++) {
+		memb[i] = s[i] == '.' ? '_' : s[i];
+	}
+	memb[i] = 0;
+	return memb;
 }
 
 /*
@@ -57,105 +57,106 @@ static char *cp_memb(const char *s) {
 
 int init_module(void)
 {
-    struct cred credstruct;
-    struct vm_area_struct vmastruct;
-    struct dentry dentrystruct;
-    struct file filestruct;
-    struct thread_info threadinfostruct;
-    struct files_struct filesstruct; /* mind the extra 's' :-P */
-    struct fdtable fdtablestruct;
-    struct vfsmount vfsmountstruct;
+	struct cred credstruct;
+	struct vm_area_struct vmastruct;
+	struct dentry dentrystruct;
+	struct file filestruct;
+	struct thread_info threadinfostruct;
+	struct files_struct filesstruct; /* mind the extra 's' :-P */
+	struct fdtable fdtablestruct;
+	struct vfsmount vfsmountstruct;
 
-    struct task_struct *ts_p;
-    struct cred *cs_p;
-    struct mm_struct *mms_p;
-    struct vm_area_struct *vma_p;
-    struct dentry *ds_p;
-    struct file *fs_p;
-    struct fdtable *fdt_p;
-    struct thread_info *ti_p;
-    struct files_struct *fss_p;
-    struct vfsmount *vfsmnt_p;
+	struct task_struct *ts_p;
+	struct cred *cs_p;
+	struct mm_struct *mms_p;
+	struct vm_area_struct *vma_p;
+	struct dentry *ds_p;
+	struct file *fs_p;
+	struct fdtable *fdt_p;
+	struct thread_info *ti_p;
+	struct files_struct *fss_p;
+	struct vfsmount *vfsmnt_p;
 
-    ts_p = &init_task;
-    cs_p = &credstruct;
-    mms_p = init_task.mm;
-    vma_p = &vmastruct;
-    ds_p = &dentrystruct;
-    fs_p = &filestruct;
-    ti_p = &threadinfostruct;
-    fss_p = &filesstruct;
-    fdt_p = &fdtablestruct;
-    vfsmnt_p = &vfsmountstruct;
+	ts_p = &init_task;
+	cs_p = &credstruct;
+	mms_p = init_task.mm;
+	vma_p = &vmastruct;
+	ds_p = &dentrystruct;
+	fs_p = &filestruct;
+	ti_p = &threadinfostruct;
+	fss_p = &filesstruct;
+	fdt_p = &fdtablestruct;
+	vfsmnt_p = &vfsmountstruct;
 
-    printk(KERN_INFO "--KERNELINFO-BEGIN--\n");
-    printk(KERN_INFO "name = %s %s\n", utsname()->version, utsname()->machine);
+	printk(KERN_INFO "--KERNELINFO-BEGIN--\n");
+	printk(KERN_INFO "name = %s %s\n", utsname()->version, utsname()->machine);
 
-    printk(KERN_INFO "task.size = %zu\n", sizeof(init_task));
-    printk(KERN_INFO "#task.init_addr = 0x%08lX\n", (unsigned long)ts_p);
-    printk(KERN_INFO "task.init_addr = %lu\n", (unsigned long)ts_p);
+	printk(KERN_INFO "task.size = %zu\n", sizeof(init_task));
+	printk(KERN_INFO "#task.init_addr = 0x%08lX\n", (unsigned long)ts_p);
+	printk(KERN_INFO "task.init_addr = %lu\n", (unsigned long)ts_p);
 
-    PRINT_OFFSET(ti_p,  task,           "task");
-    PRINT_OFFSET(ts_p,  tasks,          "task");
-    PRINT_OFFSET(ts_p,  pid,            "task");
-    PRINT_OFFSET(ts_p,  tgid,           "task");
-    PRINT_OFFSET(ts_p,  group_leader,   "task");
-    PRINT_OFFSET(ts_p,  thread_group,   "task");
-    PRINT_OFFSET(ts_p,  real_parent,    "task");
-    PRINT_OFFSET(ts_p,  parent,         "task");
-    PRINT_OFFSET(ts_p,  mm,             "task");
-    PRINT_OFFSET(ts_p,  stack,          "task");
-    PRINT_OFFSET(ts_p,  real_cred,      "task");
-    PRINT_OFFSET(ts_p,  cred,           "task");
-    PRINT_OFFSET(ts_p,  comm,           "task");
-    printk(KERN_INFO "task.comm_size = %zu\n", sizeof(ts_p->comm));
-    PRINT_OFFSET(ts_p,  files,          "task");
+	PRINT_OFFSET(ti_p,	task,			"task");
+	PRINT_OFFSET(ts_p,	tasks,			"task");
+	PRINT_OFFSET(ts_p,	pid,			"task");
+	PRINT_OFFSET(ts_p,	tgid,			"task");
+	PRINT_OFFSET(ts_p,	group_leader,	"task");
+	PRINT_OFFSET(ts_p,	thread_group,	"task");
+	PRINT_OFFSET(ts_p,	real_parent,	"task");
+	PRINT_OFFSET(ts_p,	parent,			"task");
+	PRINT_OFFSET(ts_p,	mm,				"task");
+	PRINT_OFFSET(ts_p,	stack,			"task");
+	PRINT_OFFSET(ts_p,	real_cred,		"task");
+	PRINT_OFFSET(ts_p,	cred,			"task");
+	PRINT_OFFSET(ts_p,	comm,			"task");
+	printk(KERN_INFO "task.comm_size = %zu\n", sizeof(ts_p->comm));
+	PRINT_OFFSET(ts_p,	files,			"task");
 
-    PRINT_OFFSET(cs_p,  uid,            "cred");
-    PRINT_OFFSET(cs_p,  gid,            "cred");
-    PRINT_OFFSET(cs_p,  euid,           "cred");
-    PRINT_OFFSET(cs_p,  egid,           "cred");
+	PRINT_OFFSET(cs_p,	uid,			"cred");
+	PRINT_OFFSET(cs_p,	gid,			"cred");
+	PRINT_OFFSET(cs_p,	euid,			"cred");
+	PRINT_OFFSET(cs_p,	egid,			"cred");
 
-    PRINT_OFFSET(mms_p, mmap,           "mm");
-    PRINT_OFFSET(mms_p, pgd,            "mm");
-    PRINT_OFFSET(mms_p, arg_start,      "mm");
-    PRINT_OFFSET(mms_p, start_brk,      "mm");
-    PRINT_OFFSET(mms_p, brk,            "mm");
-    PRINT_OFFSET(mms_p, start_stack,    "mm");
+	PRINT_OFFSET(mms_p, mmap,			"mm");
+	PRINT_OFFSET(mms_p, pgd,			"mm");
+	PRINT_OFFSET(mms_p, arg_start,		"mm");
+	PRINT_OFFSET(mms_p, start_brk,		"mm");
+	PRINT_OFFSET(mms_p, brk,			"mm");
+	PRINT_OFFSET(mms_p, start_stack,	"mm");
 
-    PRINT_OFFSET(vma_p, vm_mm,          "vma");
-    PRINT_OFFSET(vma_p, vm_start,       "vma");
-    PRINT_OFFSET(vma_p, vm_end,         "vma");
-    PRINT_OFFSET(vma_p, vm_next,        "vma");
-    PRINT_OFFSET(vma_p, vm_flags,       "vma");
+	PRINT_OFFSET(vma_p, vm_mm,			"vma");
+	PRINT_OFFSET(vma_p, vm_start,		"vma");
+	PRINT_OFFSET(vma_p, vm_end,			"vma");
+	PRINT_OFFSET(vma_p, vm_next,		"vma");
+	PRINT_OFFSET(vma_p, vm_flags,		"vma");
 
-    /* used in reading OsiModules */
-    PRINT_OFFSET(vma_p, vm_file,        "vma");
+	/* used in reading OsiModules */
+	PRINT_OFFSET(vma_p, vm_file,		"vma");
 
-    PRINT_OFFSET(fs_p,      f_path.dentry,  "fs");
-    PRINT_OFFSET(fs_p,      f_path.mnt,     "fs");
-    PRINT_OFFSET(vfsmnt_p,  mnt_parent,     "fs");
-    PRINT_OFFSET(vfsmnt_p,  mnt_mountpoint, "fs");
-    PRINT_OFFSET(vfsmnt_p,  mnt_root,       "fs");  /* XXX: We don't use this anywhere. Marked for removal. */
+	PRINT_OFFSET(fs_p,		f_path.dentry,	"fs");
+	PRINT_OFFSET(fs_p,		f_path.mnt,		"fs");
+	PRINT_OFFSET(vfsmnt_p,	mnt_parent,		"fs");
+	PRINT_OFFSET(vfsmnt_p,	mnt_mountpoint, "fs");
+	PRINT_OFFSET(vfsmnt_p,	mnt_root,		"fs");	/* XXX: We don't use this anywhere. Marked for removal. */
 
-    /* used in reading FDs */
-    PRINT_OFFSET(fss_p,  fdt,           "fs");
-    PRINT_OFFSET(fss_p,  fdtab,         "fs");
-    PRINT_OFFSET(fdt_p,  fd,            "fs");
+	/* used in reading FDs */
+	PRINT_OFFSET(fss_p,	fdt,			"fs");
+	PRINT_OFFSET(fss_p,	fdtab,			"fs");
+	PRINT_OFFSET(fdt_p,	fd,				"fs");
 
-    PRINT_OFFSET(ds_p,  d_name,         "fs");
-    PRINT_OFFSET(ds_p,  d_iname,        "fs");
-    PRINT_OFFSET(ds_p,  d_parent,       "fs");
-    printk(KERN_INFO "---KERNELINFO-END---\n");
+	PRINT_OFFSET(ds_p,	d_name,			"fs");
+	PRINT_OFFSET(ds_p,	d_iname,		"fs");
+	PRINT_OFFSET(ds_p,	d_parent,		"fs");
+	printk(KERN_INFO "---KERNELINFO-END---\n");
 
-    /* Return a failure. We only want to print the info. */
-    return -1;
+	/* Return a failure. We only want to print the info. */
+	return -1;
 }
 
 void cleanup_module(void)
 {
-    printk(KERN_INFO "Information module removed.\n");
+	printk(KERN_INFO "Information module removed.\n");
 }
 
 MODULE_LICENSE("GPL");
 
+/* vim:set tabstop=4 softtabstop=4 noexpandtab */

--- a/qemu/panda_plugins/osi_linux/utils/kernelinfo/kernelinfo.c
+++ b/qemu/panda_plugins/osi_linux/utils/kernelinfo/kernelinfo.c
@@ -15,9 +15,45 @@
 #include <linux/sched.h>
 #include <linux/mm.h>
 #include <linux/fs.h>
+#include <linux/file.h>
+#include <linux/fdtable.h>
 #include <linux/dcache.h>
+#include <linux/mount.h>
 
-#define PRINT_OFFSET(structp, memb, cfgname) printk(KERN_INFO "%s." #memb "_offset = %d", cfgname, (int)((void *)&(structp->memb) - (void *)structp))
+/*
+ * This function is used because to print offsets of members
+ * of nested structs. It basically transforms '.' to '_', so
+ * that we don't have to replicate all the nesting in the
+ * structs used by the introspection program.
+ *
+ * E.g. for:
+ * struct file {
+ *  ...
+ *  struct dentry {
+ *      struct *vfsmount;
+ *      struct *dentry;
+ *  }
+ *  ...
+ * };
+ *
+ * Caveat: Because a static buffer is returned, the function
+ * can only be used once in each invocation of printk.
+ */
+#define MAX_MEMBER_NAME 31
+static char *cp_memb(const char *s) {
+    static char memb[MAX_MEMBER_NAME+1];
+    int i;
+    for (i = 0; i<MAX_MEMBER_NAME && s[i]!='\0'; i++) {
+        memb[i] = s[i] == '.' ? '_' : s[i];
+    }
+    memb[i] = 0;
+    return memb;
+}
+
+/*
+ * The macro printing the config lines in the kernel log.
+ */
+#define PRINT_OFFSET(structp, memb, cfgname) printk(KERN_INFO "%s.%s_offset = %d", cfgname, cp_memb(#memb), (int)((void *)&(structp->memb) - (void *)structp))
 
 int init_module(void)
 {
@@ -26,6 +62,9 @@ int init_module(void)
     struct dentry dentrystruct;
     struct file filestruct;
     struct thread_info threadinfostruct;
+    struct files_struct filesstruct; /* mind the extra 's' :-P */
+    struct fdtable fdtablestruct;
+    struct vfsmount vfsmountstruct;
 
     struct task_struct *ts_p;
     struct cred *cs_p;
@@ -33,7 +72,10 @@ int init_module(void)
     struct vm_area_struct *vma_p;
     struct dentry *ds_p;
     struct file *fs_p;
+    struct fdtable *fdt_p;
     struct thread_info *ti_p;
+    struct files_struct *fss_p;
+    struct vfsmount *vfsmnt_p;
 
     ts_p = &init_task;
     cs_p = &credstruct;
@@ -42,6 +84,9 @@ int init_module(void)
     ds_p = &dentrystruct;
     fs_p = &filestruct;
     ti_p = &threadinfostruct;
+    fss_p = &filesstruct;
+    fdt_p = &fdtablestruct;
+    vfsmnt_p = &vfsmountstruct;
 
     printk(KERN_INFO "--KERNELINFO-BEGIN--\n");
     printk(KERN_INFO "name = %s %s\n", utsname()->version, utsname()->machine);
@@ -64,6 +109,7 @@ int init_module(void)
     PRINT_OFFSET(ts_p,  cred,           "task");
     PRINT_OFFSET(ts_p,  comm,           "task");
     printk(KERN_INFO "task.comm_size = %zu\n", sizeof(ts_p->comm));
+    PRINT_OFFSET(ts_p,  files,          "task");
 
     PRINT_OFFSET(cs_p,  uid,            "cred");
     PRINT_OFFSET(cs_p,  gid,            "cred");
@@ -85,9 +131,18 @@ int init_module(void)
 
     /* used in reading OsiModules */
     PRINT_OFFSET(vma_p, vm_file,        "vma");
-    PRINT_OFFSET(fs_p,  f_dentry,       "fs");
 
-    PRINT_OFFSET(fs_p,  f_path,         "fs");
+    PRINT_OFFSET(fs_p,      f_path.dentry,  "fs");
+    PRINT_OFFSET(fs_p,      f_path.mnt,     "fs");
+    PRINT_OFFSET(vfsmnt_p,  mnt_parent,     "fs");
+    PRINT_OFFSET(vfsmnt_p,  mnt_mountpoint, "fs");
+    PRINT_OFFSET(vfsmnt_p,  mnt_root,       "fs");  /* XXX: We don't use this anywhere. Marked for removal. */
+
+    /* used in reading FDs */
+    PRINT_OFFSET(fss_p,  fdt,           "fs");
+    PRINT_OFFSET(fss_p,  fdtab,         "fs");
+    PRINT_OFFSET(fdt_p,  fd,            "fs");
+
     PRINT_OFFSET(ds_p,  d_name,         "fs");
     PRINT_OFFSET(ds_p,  d_iname,        "fs");
     PRINT_OFFSET(ds_p,  d_parent,       "fs");

--- a/qemu/panda_plugins/osi_linux/utils/kernelinfo/kernelinfo.h
+++ b/qemu/panda_plugins/osi_linux/utils/kernelinfo/kernelinfo.h
@@ -1,10 +1,10 @@
 /*!
  * @file kernelinfo.h
  * @brief Kernel specific information used for Linux OSI.
- * 
+ *
  * @author Manolis Stamatogiannakis <manolis.stamatogiannakis@vu.nl>
- * @copyright   This work is licensed under the terms of the GNU GPL, version 2.
- *              See the COPYING file in the top-level directory. 
+ * @copyright This work is licensed under the terms of the GNU GPL, version 2.
+ * See the COPYING file in the top-level directory.
  */
 #ifndef KERNELINFO_H
 #define KERNELINFO_H
@@ -13,94 +13,94 @@
  * @brief Information and offsets related to `struct task_struct`.
  */
 struct task_info {
-    int task_offset;            /**< Offset of task_struct in the thread_info struct. */
+	int task_offset;			/**< Offset of task_struct in the thread_info struct. */
 #ifdef CPU_DEFS_H
-    /* included from qemu code */
-    /** The address of the `task_struct` of `init`. Can be used to traverse the `task_struct` list. */
-    target_ulong init_addr;
+	/* included from qemu code */
+	/** The address of the `task_struct` of `init`. Can be used to traverse the `task_struct` list. */
+	target_ulong init_addr;
 #else
-    /* used to compile the kernelinfo module */
-    /** The address of the `task_struct` of `init`. Can be used to traverse the `task_struct` list. */
-    void *init_addr;
+	/* used to compile the kernelinfo module */
+	/** The address of the `task_struct` of `init`. Can be used to traverse the `task_struct` list. */
+	void *init_addr;
 #endif
-    size_t size;                /**< Size of `struct task_struct`. */
-    int tasks_offset;           /**< TODO: add documentation for the rest of the struct members */ 
-    int pid_offset;
-    int tgid_offset;
-    int group_leader_offset;
-    int thread_group_offset;
-    int real_parent_offset;
-    int parent_offset;
-    int mm_offset;
-    int stack_offset;
-    int real_cred_offset;
-    int cred_offset;
-    int comm_offset;            /**< Offset of the command name in `struct task_struct`. */
-    size_t comm_size;           /**< Size of the command name. */
-    int files_offset;           /**< Offset for open files information. */
+	size_t size;				/**< Size of `struct task_struct`. */
+	int tasks_offset;			/**< TODO: add documentation for the rest of the struct members */
+	int pid_offset;
+	int tgid_offset;
+	int group_leader_offset;
+	int thread_group_offset;
+	int real_parent_offset;
+	int parent_offset;
+	int mm_offset;
+	int stack_offset;
+	int real_cred_offset;
+	int cred_offset;
+	int comm_offset;			/**< Offset of the command name in `struct task_struct`. */
+	size_t comm_size;			/**< Size of the command name. */
+	int files_offset;			/**< Offset for open files information. */
 };
 
 /*!
  * @brief Information and offsets related to `struct cred`.
  */
 struct cred_info {
-    int uid_offset;
-    int gid_offset;
-    int euid_offset;
-    int egid_offset;
+	int uid_offset;
+	int gid_offset;
+	int euid_offset;
+	int egid_offset;
 };
 
 /*!
  * @brief Information and offsets related to `struct mm_struct`.
  */
 struct mm_info {
-    int mmap_offset;
-    int pgd_offset;
-    int arg_start_offset;
-    int start_brk_offset;
-    int brk_offset;
-    int start_stack_offset;
+	int mmap_offset;
+	int pgd_offset;
+	int arg_start_offset;
+	int start_brk_offset;
+	int brk_offset;
+	int start_stack_offset;
 };
 
 /*!
  * @brief Information and offsets related to `struct vm_area_struct`.
  */
 struct vma_info {
-    int vm_mm_offset;
-    int vm_start_offset;
-    int vm_end_offset;
-    int vm_next_offset;
-    int vm_file_offset;
-    int vm_flags_offset;
+	int vm_mm_offset;
+	int vm_start_offset;
+	int vm_end_offset;
+	int vm_next_offset;
+	int vm_file_offset;
+	int vm_flags_offset;
 };
 
 /*!
  * @brief Filesystem information and offsets.
  */
 struct fs_info {
-    int f_path_dentry_offset;
-    int f_path_mnt_offset;
-    int mnt_parent_offset;
-    int mnt_mountpoint_offset;
-    int mnt_root_offset;
-    int d_name_offset;
-    int d_iname_offset;
-    int d_parent_offset;
-    int fdt_offset;
-    int fdtab_offset;
-    int fd_offset;
+	int f_path_dentry_offset;
+	int f_path_mnt_offset;
+	int mnt_parent_offset;
+	int mnt_mountpoint_offset;
+	int mnt_root_offset;
+	int d_name_offset;
+	int d_iname_offset;
+	int d_parent_offset;
+	int fdt_offset;
+	int fdtab_offset;
+	int fd_offset;
 };
 
 /*!
  * @brief Wrapper for the structure-specific structs.
  */
 struct kernelinfo {
-    char *name;
-    struct task_info task;
-    struct cred_info cred;
-    struct mm_info mm;
-    struct vma_info vma;
-    struct fs_info fs;
+	char *name;
+	struct task_info task;
+	struct cred_info cred;
+	struct mm_info mm;
+	struct vma_info vma;
+	struct fs_info fs;
 };
 
 
@@ -114,3 +114,5 @@ struct kernelinfo {
 int read_kernelinfo(gchar const *file, gchar const *group, struct kernelinfo *ki);
 #endif
 #endif
+
+/* vim:set tabstop=4 softtabstop=4 noexpandtab */

--- a/qemu/panda_plugins/osi_linux/utils/kernelinfo/kernelinfo.h
+++ b/qemu/panda_plugins/osi_linux/utils/kernelinfo/kernelinfo.h
@@ -37,6 +37,7 @@ struct task_info {
     int cred_offset;
     int comm_offset;            /**< Offset of the command name in `struct task_struct`. */
     size_t comm_size;           /**< Size of the command name. */
+    int files_offset;           /**< Offset for open files information. */
 };
 
 /*!
@@ -74,14 +75,20 @@ struct vma_info {
 };
 
 /*!
- * @brief Misc information and offsets.
+ * @brief Filesystem information and offsets.
  */
 struct fs_info {
-    int f_dentry_offset;
-    int f_path_offset;
+    int f_path_dentry_offset;
+    int f_path_mnt_offset;
+    int mnt_parent_offset;
+    int mnt_mountpoint_offset;
+    int mnt_root_offset;
     int d_name_offset;
     int d_iname_offset;
     int d_parent_offset;
+    int fdt_offset;
+    int fdtab_offset;
+    int fd_offset;
 };
 
 /*!

--- a/qemu/panda_plugins/osi_linux/utils/kernelinfo/kernelinfo_read.c
+++ b/qemu/panda_plugins/osi_linux/utils/kernelinfo/kernelinfo_read.c
@@ -80,6 +80,7 @@ int read_kernelinfo(gchar const *file, gchar const *group, struct kernelinfo *ki
     READ_INFO_INT(task.cred_offset, err, err_task);
     READ_INFO_INT(task.comm_offset, err, err_task);
     READ_INFO_INT(task.comm_size, err, err_task);
+    READ_INFO_INT(task.files_offset, err, err_task);
 
     /* init_task address is always read as uint64 and then cast to (target-specific) target_ulong */
     init_addr = g_key_file_get_uint64(keyfile, group_real, "task.init_addr", &err);
@@ -109,11 +110,17 @@ int read_kernelinfo(gchar const *file, gchar const *group, struct kernelinfo *ki
     READ_INFO_INT(vma.vm_flags_offset, err, err_vma);
 
     /* read fs information */
-    READ_INFO_INT(fs.f_dentry_offset, err, err_fs);
-    READ_INFO_INT(fs.f_path_offset, err, err_fs);
+    READ_INFO_INT(fs.f_path_dentry_offset, err, err_fs);
+    READ_INFO_INT(fs.f_path_mnt_offset, err, err_fs);
+    READ_INFO_INT(fs.mnt_parent_offset, err, err_fs);
+    READ_INFO_INT(fs.mnt_mountpoint_offset, err, err_fs);
+    READ_INFO_INT(fs.mnt_root_offset, err, err_fs);
     READ_INFO_INT(fs.d_name_offset, err, err_fs);
     READ_INFO_INT(fs.d_iname_offset, err, err_fs);
     READ_INFO_INT(fs.d_parent_offset, err, err_fs);
+    READ_INFO_INT(fs.fdt_offset, err, err_fs);
+    READ_INFO_INT(fs.fdtab_offset, err, err_fs);
+    READ_INFO_INT(fs.fd_offset, err, err_fs);
 
     /* read kernel full name */
     READ_INFO_STRING(name, err, err_misc);

--- a/qemu/panda_plugins/osi_linux/utils/kernelinfo/kernelinfo_read.c
+++ b/qemu/panda_plugins/osi_linux/utils/kernelinfo/kernelinfo_read.c
@@ -5,14 +5,14 @@
  * @see https://developer.gnome.org/glib/stable/glib-Key-value-file-parser.html
  *
  * @author Manolis Stamatogiannakis <manolis.stamatogiannakis@vu.nl>
- * @copyright   This work is licensed under the terms of the GNU GPL, version 2.
- *              See the COPYING file in the top-level directory. 
+ * @copyright This work is licensed under the terms of the GNU GPL, version 2.
+ * See the COPYING file in the top-level directory.
  */
 #include <stdio.h>
 #include <string.h>
 #include <glib.h>
 #include "cpu.h"
-#include "kernelinfo.h"	    /* must come after cpu.h, glib.h */
+#include "kernelinfo.h"	/* must come after cpu.h, glib.h */
 
 #define ERRLOG_OUT stderr
 #define ERRLOG(fmt, args...) fprintf(ERRLOG_OUT, "ERROR(%s:%s): " fmt "\n", basename(__FILE__), __func__, ## args)
@@ -21,19 +21,19 @@
  * @brief Convenience wrapper for reading `int` values from keyfile and handling any errors.
  */
 #define READ_INFO_INT(mname, errp, errcount) (ki->mname) = g_key_file_get_integer(keyfile, group_real, #mname, &err); \
-    if (err != NULL) { errcount++; g_error_free(errp); errp = NULL; ERRLOG("Couldn't read " #mname "."); }
+	if (err != NULL) { errcount++; g_error_free(errp); errp = NULL; ERRLOG("Couldn't read " #mname "."); }
 
 /*!
  * @brief Convenience wrapper for reading unsigned 64bit values from keyfile and handling any errors.
  */
 #define READ_INFO_UINT64(mname, errp, errcount) (ki->mname) = g_key_file_get_uint64(keyfile, group_real, #mname, &err); \
-    if (err != NULL) { errcount++; g_error_free(errp); errp = NULL; }
+	if (err != NULL) { errcount++; g_error_free(errp); errp = NULL; }
 
 /*!
  * @brief Convenience wrapper for reading string values from keyfile and handling any errors.
  */
 #define READ_INFO_STRING(mname, errp, errcount) (ki->mname) = g_key_file_get_string(keyfile, group_real, #mname, &err); \
-    if (err != NULL) { errcount++; g_error_free(errp); errp = NULL; }
+	if (err != NULL) { errcount++; g_error_free(errp); errp = NULL; }
 
 /*! Reads kernel information (struct offsets and such) from the specified file.
  *
@@ -46,96 +46,97 @@
  * \return 0 for success. -1 for failure.
  */
 int read_kernelinfo(gchar const *file, gchar const *group, struct kernelinfo *ki) {
-    GError *err = NULL;
-    GKeyFile *keyfile;
-    gchar *group_real = NULL;
-    int err_task = 0, err_mm = 0, err_cred = 0, err_vma = 0, err_fs = 0, err_misc = 0;
-    uint64 init_addr = 0;
+	GError *err = NULL;
+	GKeyFile *keyfile;
+	gchar *group_real = NULL;
+	int err_task = 0, err_mm = 0, err_cred = 0, err_vma = 0, err_fs = 0, err_misc = 0;
+	uint64 init_addr = 0;
 
-    /* open file */
-    memset(ki, '\0', sizeof(struct kernelinfo));
-    keyfile = g_key_file_new();
-    g_key_file_load_from_file (keyfile, (file != NULL ? file : DEFAULT_KERNELINFO_FILE), G_KEY_FILE_NONE, &err);
-    if (err != NULL) goto error;
+	/* open file */
+	memset(ki, '\0', sizeof(struct kernelinfo));
+	keyfile = g_key_file_new();
+	g_key_file_load_from_file (keyfile, (file != NULL ? file : DEFAULT_KERNELINFO_FILE), G_KEY_FILE_NONE, &err);
+	if (err != NULL) goto error;
 
-    /* get group */
-    if (group != NULL) group_real = g_strdup(group);
-    else group_real = g_key_file_get_start_group(keyfile);
-    if (!g_key_file_has_group(keyfile, group_real)) goto error;
+	/* get group */
+	if (group != NULL) group_real = g_strdup(group);
+	else group_real = g_key_file_get_start_group(keyfile);
+	if (!g_key_file_has_group(keyfile, group_real)) goto error;
 
-    /* read task information */
-    READ_INFO_INT(task.task_offset, err, err_fs);
-    READ_INFO_INT(task.tasks_offset, err, err_task);
-    READ_INFO_INT(task.size, err, err_task);
-    //READ_INFO_INT(task.list_offset, err, err_task);
-    READ_INFO_INT(task.pid_offset, err, err_task);
-    READ_INFO_INT(task.tgid_offset, err, err_task);
-    READ_INFO_INT(task.group_leader_offset, err, err_task);
-    READ_INFO_INT(task.thread_group_offset, err, err_task);
-    READ_INFO_INT(task.real_parent_offset, err, err_task);
-    READ_INFO_INT(task.parent_offset, err, err_task);
-    READ_INFO_INT(task.mm_offset, err, err_task);
-    READ_INFO_INT(task.stack_offset, err, err_task);
-    READ_INFO_INT(task.real_cred_offset, err, err_task);
-    READ_INFO_INT(task.cred_offset, err, err_task);
-    READ_INFO_INT(task.comm_offset, err, err_task);
-    READ_INFO_INT(task.comm_size, err, err_task);
-    READ_INFO_INT(task.files_offset, err, err_task);
+	/* read task information */
+	READ_INFO_INT(task.task_offset, err, err_fs);
+	READ_INFO_INT(task.tasks_offset, err, err_task);
+	READ_INFO_INT(task.size, err, err_task);
+	//READ_INFO_INT(task.list_offset, err, err_task);
+	READ_INFO_INT(task.pid_offset, err, err_task);
+	READ_INFO_INT(task.tgid_offset, err, err_task);
+	READ_INFO_INT(task.group_leader_offset, err, err_task);
+	READ_INFO_INT(task.thread_group_offset, err, err_task);
+	READ_INFO_INT(task.real_parent_offset, err, err_task);
+	READ_INFO_INT(task.parent_offset, err, err_task);
+	READ_INFO_INT(task.mm_offset, err, err_task);
+	READ_INFO_INT(task.stack_offset, err, err_task);
+	READ_INFO_INT(task.real_cred_offset, err, err_task);
+	READ_INFO_INT(task.cred_offset, err, err_task);
+	READ_INFO_INT(task.comm_offset, err, err_task);
+	READ_INFO_INT(task.comm_size, err, err_task);
+	READ_INFO_INT(task.files_offset, err, err_task);
 
-    /* init_task address is always read as uint64 and then cast to (target-specific) target_ulong */
-    init_addr = g_key_file_get_uint64(keyfile, group_real, "task.init_addr", &err);
-    if (err != NULL) { err_task++; g_error_free(err); err = NULL; ERRLOG("Couldn't read task.init_addr."); }
-    else { ki->task.init_addr = (target_ulong)init_addr; }
-    
-    /* read cred information */
-    READ_INFO_INT(cred.uid_offset, err, err_cred);
-    READ_INFO_INT(cred.gid_offset, err, err_cred);
-    READ_INFO_INT(cred.euid_offset, err, err_cred);
-    READ_INFO_INT(cred.egid_offset, err, err_cred);
+	/* init_task address is always read as uint64 and then cast to (target-specific) target_ulong */
+	init_addr = g_key_file_get_uint64(keyfile, group_real, "task.init_addr", &err);
+	if (err != NULL) { err_task++; g_error_free(err); err = NULL; ERRLOG("Couldn't read task.init_addr."); }
+	else { ki->task.init_addr = (target_ulong)init_addr; }
 
-    /* read mm information */
-    READ_INFO_INT(mm.mmap_offset, err, err_mm);
-    READ_INFO_INT(mm.pgd_offset, err, err_mm);
-    READ_INFO_INT(mm.arg_start_offset, err, err_mm);
-    READ_INFO_INT(mm.start_brk_offset, err, err_mm);
-    READ_INFO_INT(mm.brk_offset, err, err_mm);
-    READ_INFO_INT(mm.start_stack_offset, err, err_mm);
+	/* read cred information */
+	READ_INFO_INT(cred.uid_offset, err, err_cred);
+	READ_INFO_INT(cred.gid_offset, err, err_cred);
+	READ_INFO_INT(cred.euid_offset, err, err_cred);
+	READ_INFO_INT(cred.egid_offset, err, err_cred);
 
-    /* read vma information */
-    READ_INFO_INT(vma.vm_mm_offset, err, err_vma);
-    READ_INFO_INT(vma.vm_start_offset, err, err_vma);
-    READ_INFO_INT(vma.vm_end_offset, err, err_vma);
-    READ_INFO_INT(vma.vm_next_offset, err, err_vma);
-    READ_INFO_INT(vma.vm_file_offset, err, err_vma);
-    READ_INFO_INT(vma.vm_flags_offset, err, err_vma);
+	/* read mm information */
+	READ_INFO_INT(mm.mmap_offset, err, err_mm);
+	READ_INFO_INT(mm.pgd_offset, err, err_mm);
+	READ_INFO_INT(mm.arg_start_offset, err, err_mm);
+	READ_INFO_INT(mm.start_brk_offset, err, err_mm);
+	READ_INFO_INT(mm.brk_offset, err, err_mm);
+	READ_INFO_INT(mm.start_stack_offset, err, err_mm);
 
-    /* read fs information */
-    READ_INFO_INT(fs.f_path_dentry_offset, err, err_fs);
-    READ_INFO_INT(fs.f_path_mnt_offset, err, err_fs);
-    READ_INFO_INT(fs.mnt_parent_offset, err, err_fs);
-    READ_INFO_INT(fs.mnt_mountpoint_offset, err, err_fs);
-    READ_INFO_INT(fs.mnt_root_offset, err, err_fs);
-    READ_INFO_INT(fs.d_name_offset, err, err_fs);
-    READ_INFO_INT(fs.d_iname_offset, err, err_fs);
-    READ_INFO_INT(fs.d_parent_offset, err, err_fs);
-    READ_INFO_INT(fs.fdt_offset, err, err_fs);
-    READ_INFO_INT(fs.fdtab_offset, err, err_fs);
-    READ_INFO_INT(fs.fd_offset, err, err_fs);
+	/* read vma information */
+	READ_INFO_INT(vma.vm_mm_offset, err, err_vma);
+	READ_INFO_INT(vma.vm_start_offset, err, err_vma);
+	READ_INFO_INT(vma.vm_end_offset, err, err_vma);
+	READ_INFO_INT(vma.vm_next_offset, err, err_vma);
+	READ_INFO_INT(vma.vm_file_offset, err, err_vma);
+	READ_INFO_INT(vma.vm_flags_offset, err, err_vma);
 
-    /* read kernel full name */
-    READ_INFO_STRING(name, err, err_misc);
- 
-    /* check the sum of errors */
-    if (err_task + err_cred + err_mm + err_vma + err_fs + err_misc == 0) {
-	g_key_file_free(keyfile);
-	g_free(group_real);
-	return 0;
-    }
+	/* read fs information */
+	READ_INFO_INT(fs.f_path_dentry_offset, err, err_fs);
+	READ_INFO_INT(fs.f_path_mnt_offset, err, err_fs);
+	READ_INFO_INT(fs.mnt_parent_offset, err, err_fs);
+	READ_INFO_INT(fs.mnt_mountpoint_offset, err, err_fs);
+	READ_INFO_INT(fs.mnt_root_offset, err, err_fs);
+	READ_INFO_INT(fs.d_name_offset, err, err_fs);
+	READ_INFO_INT(fs.d_iname_offset, err, err_fs);
+	READ_INFO_INT(fs.d_parent_offset, err, err_fs);
+	READ_INFO_INT(fs.fdt_offset, err, err_fs);
+	READ_INFO_INT(fs.fdtab_offset, err, err_fs);
+	READ_INFO_INT(fs.fd_offset, err, err_fs);
 
-    error:
-        g_key_file_free(keyfile);
-	g_free(group_real);
-	g_free(ki->name);
-        return -1;
+	/* read kernel full name */
+	READ_INFO_STRING(name, err, err_misc);
+
+	/* check the sum of errors */
+	if (err_task + err_cred + err_mm + err_vma + err_fs + err_misc == 0) {
+		g_key_file_free(keyfile);
+		g_free(group_real);
+		return 0;
+	}
+
+	error:
+		g_key_file_free(keyfile);
+		g_free(group_real);
+		g_free(ki->name);
+		return -1;
 }
 
+/* vim:set tabstop=4 softtabstop=4 noexpandtab */


### PR DESCRIPTION
Check commit 20d12e3 for the implementation. Second commit (5b35a48) only fixes sloppy indentation throughout `osi_linux`.

The API call added is  `osi_linux.cpp::osi_linux_resolve_fd()`, which is a "user-friendly" wrapper for `osi_linux.cpp::get_fd_name()`. The latter uses the helper functions: `osi_linux.cpp::get_file_name()`, ` osi_linux.h::read_dentry_name()`, `osi_linux.h::read_vfsmount_name()`.

To use the call, `init_osi_linux_api()` has to be called from each source file.
