### PR TITLE
Makefile fix for callstack_instr.

### DIFF
--- a/qemu/panda_plugins/callstack_instr/Makefile
+++ b/qemu/panda_plugins/callstack_instr/Makefile
@@ -19,6 +19,6 @@ LIBS+=-ldistorm3
 $(PLUGIN_TARGET_DIR)/$(PLUGIN_NAME).o: $(PLUGIN_SRC_ROOT)/$(PLUGIN_NAME)/$(PLUGIN_NAME).cpp
 
 $(PLUGIN_TARGET_DIR)/panda_$(PLUGIN_NAME).so: $(PLUGIN_TARGET_DIR)/$(PLUGIN_NAME).o
-	$(call quiet-command,$(CXX) $(QEMU_CFLAGS) -shared -o $@ $^ $(LIBS),"  PLUGIN  $@")
+	$(call quiet-command,$(CXX) $(QEMU_CFLAGS) -shared -o $@ $^ $(LDFLAGS) $(LIBS),"  PLUGIN  $@")
 
 all: $(PLUGIN_TARGET_DIR)/panda_$(PLUGIN_NAME).so


### PR DESCRIPTION
Added LDFLAGS to callstack_instr. callstack_instr needs distorm3 which is installed in /usr/local.