### PR TITLE
Build-related fixes.

### DIFF
--- a/qemu/build.sh
+++ b/qemu/build.sh
@@ -41,6 +41,6 @@ fi
 $LLVM_BIT \
 --extra-cflags="-O2 -I/usr/local/include" \
 --extra-cxxflags="-O2" \
---extra-ldflags="-L/usr/local/lib -L/usr/local/lib64 -L/usr/local/lib -lprotobuf-c -lprotobuf -lpthread"
+--extra-ldflags="-L/usr/local/lib -L/usr/local/lib64 -lprotobuf-c -lprotobuf -lpthread"
 
 make -j ${PANDA_NPROC:-$(nproc)}

--- a/qemu/configure
+++ b/qemu/configure
@@ -3831,10 +3831,6 @@ if test "$smartcard_nss" = "yes" ; then
   echo "libcacard_cflags=$libcacard_cflags" >> $config_host_mak
 fi
 
-if [ "$llvm" = "yes" ]; then
-   echo "LIBS:=$llvm_libs $llvm_ldflags \$(LIBS)" >> $config_target_mak
-fi
-
 list=""
 if test ! -z "$gdb_xml_files" ; then
   for x in $gdb_xml_files; do

--- a/qemu/panda_plugins/Makefile.example
+++ b/qemu/panda_plugins/Makefile.example
@@ -20,6 +20,6 @@ PLUGIN_OBJFILES=$(PLUGIN_OBJ_DIR)/$(PLUGIN_NAME).o\
 
 # Plugin dynamic library. Please stick with the panda_ naming convention.
 $(PLUGIN_TARGET_DIR)/panda_$(PLUGIN_NAME).so: $(PLUGIN_OBJFILES)
-	$(call quiet-command,$(CC) $(QEMU_CFLAGS) -shared -o $@ $^ $(LIBS),"  PLUGIN  $@")
+	$(call quiet-command,$(CC) $(QEMU_CFLAGS) -shared -o $@ $^ $(LDFLAGS) $(LIBS),"  PLUGIN  $@")
 
 all: $(PLUGIN_OBJ_DIR) $(PLUGIN_TARGET_DIR)/panda_$(PLUGIN_NAME).so

--- a/qemu/panda_plugins/pri_dwarf/Makefile
+++ b/qemu/panda_plugins/pri_dwarf/Makefile
@@ -14,6 +14,6 @@ LIBS+=-ldwarf -lelf
 # The main rule for your plugin. Please stick with the panda_ naming
 # convention.
 $(PLUGIN_TARGET_DIR)/panda_$(PLUGIN_NAME).so: $(PLUGIN_TARGET_DIR)/$(PLUGIN_NAME).o
-	$(call quiet-command,$(CXX) $(QEMU_CFLAGS) -shared -o $@ $^ $(LIBS),"  PLUGIN  $@")
+	$(call quiet-command,$(CXX) $(QEMU_CFLAGS) -shared -o $@ $^ $(LDFLAGS) $(LIBS),"  PLUGIN  $@")
 
 all: $(PLUGIN_TARGET_DIR)/panda_$(PLUGIN_NAME).so


### PR DESCRIPTION
* LDFLAGS is needed when linking pri_dwarf, otherwise the linker will prefer the dwarf library from /usr/lib, if one is installed.
* Added LDFLAGS to plugin template makefile, to avoid similar issues in future.
* Fixed configure to avoid adding LLVM linker flags twice.