### PR TITLE
minor fixes for file_taint documentation/code readablity

### DIFF
--- a/qemu/panda_plugins/file_taint/USAGE.md
+++ b/qemu/panda_plugins/file_taint/USAGE.md
@@ -16,7 +16,7 @@ Arguments
 ---------
 
 * `filename`: string, defaults to "abc123". The filename we want to taint.
-* `pos`: boolean, whether to use *positional labels*, i.e. labels that correspond to 
+* `pos`: boolean, defaults to false. Enables use of positional labels. I.e. the file offset where the data were read from is used as their initial taint label.
 * `notaint`: boolean: whether to actually do any tainting. This option is useful because we can run `file_taint` without taint to find out when the first use of the file in the replay is, and then re-run it with the `first_instr` option to turn on taint just before the file is opened. This can dramatically speed up the process, since running with taint enabled (even if nothing is tainted) can be very slow.
 * `max_num_labels` ulong, defaults to 1000000. How many labels to apply to input bytes. The default value corresponds to a roughly 1MB chunk of the file.
 * `start`: ulong, the first offset in the file to label.

--- a/qemu/panda_plugins/file_taint/file_taint.cpp
+++ b/qemu/panda_plugins/file_taint/file_taint.cpp
@@ -44,9 +44,9 @@ extern "C" {
 static bool debug = true;
  
 const char *taint_filename = 0;
-bool positional_labels = true;
-bool no_taint = true;
-bool enable_taint_on_open = false;
+bool positional_labels;
+bool no_taint;
+bool enable_taint_on_open;
 
 extern uint64_t replay_get_guest_instr_count(void);
 
@@ -430,7 +430,6 @@ bool init_plugin(void *self) {
     args = panda_get_args("file_taint");
     taint_filename = panda_parse_string(args, "filename", "abc123");
     positional_labels = panda_parse_bool(args, "pos");
-    // used to just find the names of files that get 
     no_taint = panda_parse_bool(args, "notaint");
     end_label = panda_parse_ulong(args, "max_num_labels", 1000000);
     end_label = panda_parse_ulong(args, "end", end_label);


### PR DESCRIPTION
- Finished the half-done documentation for pos argument.
- Removed superfluous initializations of booleans (readability).