### PR TITLE
Dump packets to pcapng instead of pcap format.

### DIFF
--- a/panda_install.bash
+++ b/panda_install.bash
@@ -25,7 +25,7 @@ sudo apt-get -y install build-essential
 progress "Installing PANDA dependencies..."
 sudo apt-get -y install nasm libssl-dev libpcap-dev subversion curl autoconf libtool \
   python-pip git protobuf-compiler protobuf-c-compiler libprotobuf-c0-dev libprotoc-dev \
-  libglib2.0-dev libelf-dev
+  libglib2.0-dev libelf-dev libwiretap-dev libwsutil-dev
 
 cwd=$(pwd)
 cd /tmp

--- a/qemu/panda_plugins/network/Makefile
+++ b/qemu/panda_plugins/network/Makefile
@@ -8,8 +8,8 @@ PLUGIN_NAME=network
 include ../panda.mak
 
 # If you need custom CFLAGS or LIBS, set them up here
-CXXFLAGS+=$(shell pkg-config --cflags wireshark)
-LIBS+=$(shell pkg-config --libs wireshark) -lwiretap
+CXXFLAGS+=-I/usr/include/wireshark
+LIBS+=-lwiretap
 
 # The main rule for your plugin. Please stick with the panda_ naming
 # convention.

--- a/qemu/panda_plugins/network/Makefile
+++ b/qemu/panda_plugins/network/Makefile
@@ -8,8 +8,8 @@ PLUGIN_NAME=network
 include ../panda.mak
 
 # If you need custom CFLAGS or LIBS, set them up here
-# CFLAGS+=
-LIBS+=-lpcap
+CXXFLAGS+=$(shell pkg-config --cflags wireshark)
+LIBS+=$(shell pkg-config --libs wireshark) -lwiretap
 
 # The main rule for your plugin. Please stick with the panda_ naming
 # convention.


### PR DESCRIPTION
This allows to add additional information in frames' comments.
For instance, the guest instruction number is dumped in each frame,
which allows very precise scissoring to interesting execution
snippets.