### PR TITLE
[scissors] Fix incorrect replay replication.

### DIFF
--- a/qemu/panda_plugins/sample/sample.c
+++ b/qemu/panda_plugins/sample/sample.c
@@ -140,7 +140,8 @@ int exec_callback(CPUState *env, target_ulong pc) {
     // testing and debugging
     unsigned char buf[15];
     panda_virtual_memory_rw(env, pc, buf, 15, 0);
-    for (int i = 0; i < 15; i++) {
+    int i;
+    for (i = 0; i < 15; i++) {
         fprintf(plugin_log, " %02x", buf[i]);
     }
     fprintf(plugin_log, "\n");

--- a/qemu/rr_log.c
+++ b/qemu/rr_log.c
@@ -675,7 +675,7 @@ static inline RR_log_entry *alloc_new_entry(void)
 static RR_log_entry *rr_read_item(void) {
     RR_log_entry *item = alloc_new_entry();
 
-    item->file_pos = ftell(rr_nondet_log->fp);
+    item->file_pos = rr_nondet_log->bytes_read;
 
     //mz read header
     rr_assert (rr_in_replay());

--- a/qemu/rr_log.c
+++ b/qemu/rr_log.c
@@ -675,6 +675,8 @@ static inline RR_log_entry *alloc_new_entry(void)
 static RR_log_entry *rr_read_item(void) {
     RR_log_entry *item = alloc_new_entry();
 
+    item->file_pos = ftell(rr_nondet_log->fp);
+
     //mz read header
     rr_assert (rr_in_replay());
     rr_assert ( ! rr_log_is_empty());
@@ -1287,6 +1289,10 @@ void rr_create_record_log (const char *filename) {
   //This way, when we print progress, we can use something better than size of log consumed
   //(as that can jump //sporadically).
   fwrite(&(rr_nondet_log->last_prog_point), sizeof(RR_prog_point), 1, rr_nondet_log->fp);
+
+  // For record logs the current_item's file position will never be
+  // touched; we set it to -1 so it does not confuse anyone
+  rr_nondet_log->current_item.file_pos = -1;
 }
 
 

--- a/qemu/rr_log.h
+++ b/qemu/rr_log.h
@@ -104,6 +104,7 @@ typedef struct rr_log_entry_t {
         // no variant fields
     } variant;
     struct rr_log_entry_t *next;
+  long file_pos;
 } RR_log_entry;
 
 // a program-point indexed record/replay log

--- a/qemu/rr_print.c
+++ b/qemu/rr_print.c
@@ -86,7 +86,8 @@ static void rr_spit_log_entry(RR_log_entry item) {
                                args->variant.cpu_mem_rw_args.addr,
                                args->variant.cpu_mem_rw_args.len);
                         printf("Buffer:");
-                        for (int i = 0; i < args->variant.cpu_mem_rw_args.len && i < 16; i++) {
+                        int i;
+                        for (i = 0; i < args->variant.cpu_mem_rw_args.len && i < 16; i++) {
                             printf(" %02x", args->variant.cpu_mem_rw_args.buf[i]);
                         }
                         if (args->variant.cpu_mem_rw_args.len >= 16) {


### PR DESCRIPTION
The scissors plugin used to have a bug that led to incorrect buffer
copying for some RR_CALL_CPU_MEM_RW items being in the log queue in
the moment the plugin itself began working. This produced log not
conforming to the original one and causing the replay to fail.

Although the exact error source is not known to me, this commit
introduce a small architectural change in the scissors plugin which
makes it design cleaner, removes a lot of nearly duplicate code
and solves the bug.

Specifically, the scissors plugin used to write the first log items
from the active replay queue (and here the bug occurred), then
began trivially copying the content of the log file, just shifting
the instruction counts. Now the first step has been removed. In
order to allow the scissors plugin to know where to begin copying
the old log file, the RR_log_entry struct has been extended with a
field containing the offset at which that specific entry was read
from the log file.